### PR TITLE
refactor: api 명세에 맞게 데이터 fetching 수정

### DIFF
--- a/src/assets/icons/participants.svg
+++ b/src/assets/icons/participants.svg
@@ -1,0 +1,6 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M17 21V19C17 17.9391 16.5786 16.9217 15.8284 16.1716C15.0783 15.4214 14.0609 15 13 15H5C3.93913 15 2.92172 15.4214 2.17157 16.1716C1.42143 16.9217 1 17.9391 1 19V21" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M9 11C11.2091 11 13 9.20914 13 7C13 4.79086 11.2091 3 9 3C6.79086 3 5 4.79086 5 7C5 9.20914 6.79086 11 9 11Z" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M23 21V19C22.9993 18.1137 22.7044 17.2528 22.1614 16.5523C21.6184 15.8519 20.8581 15.3516 20 15.13" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M16 3.13C16.8604 3.35031 17.623 3.85071 18.1676 4.55232C18.7122 5.25392 19.0078 6.11683 19.0078 7.005C19.0078 7.89318 18.7122 8.75608 18.1676 9.45769C17.623 10.1593 16.8604 10.6597 16 10.88" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/details/BuyersFooter.tsx
+++ b/src/components/details/BuyersFooter.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+
+interface BuyersFooterProps {
+  isSeller: boolean;
+  status: string;
+  isParticipating: boolean;
+  remainingBidCount: number;
+}
+
+const BuyersFooter: React.FC<BuyersFooterProps> = ({
+  isSeller,
+  status,
+  isParticipating,
+  remainingBidCount,
+}) => {
+  // 판매자가 아닌 경우에만 footer 표시
+  if (isSeller) return null;
+
+  // 1. 판매자가 아니면서 경매 아이템이 PENDING일 경우
+  if (status === 'PENDING') {
+    return (
+      <div className="bg-gray-200 text-center p-2 rounded-lg">
+        오픈 알림 받기
+      </div>
+    );
+  }
+
+  // 2. 판매자가 아니면서 경매 아이템이 PROCEEDING이고, 아직 참여하지 않았을 경우
+  if (status === 'PROCEEDING' && !isParticipating) {
+    return (
+      <button className="bg-orange-500 text-white rounded-lg px-4 py-2 hover:bg-orange-600 transition-colors">
+        경매 참여하기
+      </button>
+    );
+  }
+
+  // 3. 판매자가 아니면서 경매 아이템이 PROCEEDING이고, 경매에 참여했으면서 가격 수정 횟수가 남아있을 때
+  if (status === 'PROCEEDING' && isParticipating && remainingBidCount > 0) {
+    return (
+      <div className="flex justify-between items-center p-2 rounded-lg">
+        <button className="border border-gray-400 text-gray-600 rounded-lg px-4 py-2">
+          참여 취소
+        </button>
+        <button className="bg-orange-500 text-white rounded-lg px-4 py-2 hover:bg-orange-600 transition-colors">
+          금액 수정({remainingBidCount}회 가능)
+        </button>
+      </div>
+    );
+  }
+
+  // 4. 판매자가 아니면서 경매 아이템이 PROCEEDING이고, 경매에 참여했으면서 가격 수정 횟수가 모두 소진됐을 때
+  if (status === 'PROCEEDING' && isParticipating && remainingBidCount === 0) {
+    return (
+      <div className="flex justify-between items-center p-2 rounded-lg">
+        <button className="border border-gray-400 text-gray-600 rounded-lg px-4 py-2">
+          참여 취소
+        </button>
+        <button className="bg-gray-400 text-white rounded-lg px-4 py-2 cursor-not-allowed">
+          금액 수정(소진)
+        </button>
+      </div>
+    );
+  }
+
+  // 5. 경매가 종료되었을 때
+  if (status === 'COMPLETED') {
+    return (
+      <div className="bg-gray-300 text-center p-2 rounded-lg">종료된 경매</div>
+    );
+  }
+
+  return null;
+};
+
+export default BuyersFooter;

--- a/src/components/details/ProgressBar.tsx
+++ b/src/components/details/ProgressBar.tsx
@@ -1,16 +1,42 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import { useProgress } from '@/hooks/useProgress';
 
 interface ProgressBarProps {
-  progressBarWidth: number;
+  auctionStartTime: number;
+  serverCurrentTime: number;
+  totalTime: number;
+  isLoading: boolean;
 }
 
-const ProgressBar: React.FC<ProgressBarProps> = ({ progressBarWidth }) => {
+const ProgressBar: React.FC<ProgressBarProps> = ({
+  auctionStartTime,
+  serverCurrentTime,
+  totalTime,
+  isLoading,
+}) => {
+  const { formattedTime, progressBarWidth } = useProgress(
+    auctionStartTime,
+    serverCurrentTime,
+    totalTime,
+    isLoading,
+  );
+
+  const isHalfTime = progressBarWidth <= 50;
+  const progressBarColor = isHalfTime ? 'bg-red-500' : 'bg-green-500';
+
   return (
-    <div className="w-full h-1 bg-gray-200">
+    <div>
       <div
-        className="h-full bg-green-500"
-        style={{ width: `${progressBarWidth}%` }}
-      />
+        className={`text-center text-lg font-bold ${isHalfTime ? 'text-red-500' : 'text-green-500'}`}
+      >
+        {formattedTime}
+      </div>
+      <div className="w-full h-1 bg-gray-200">
+        <div
+          className={`h-full ${progressBarColor}`}
+          style={{ width: `${progressBarWidth}%` }}
+        />
+      </div>
     </div>
   );
 };

--- a/src/components/details/SellersFooter.tsx
+++ b/src/components/details/SellersFooter.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import Button from '@/components/common/Button';
+import { AiOutlineHeart } from 'react-icons/ai';
+
+interface SellersFooterProps {
+  isSeller: boolean;
+  status: string;
+}
+
+const SellersFooter: React.FC<SellersFooterProps> = ({ isSeller, status }) => {
+  const interestCount = 0; // Define interestCount or get it from props/state
+
+  if (isSeller && status === 'PENDING') {
+    return (
+      <div className="bg-gray-300 text-gray-600 p-4 rounded-lg text-center border border-dashed border-blue-200">
+        내가 올린 경매
+      </div>
+    );
+  }
+
+  if (isSeller && status === 'PROCEEDING') {
+    return (
+      <div className="flex items-center flex-1 h-full gap-2">
+        <AiOutlineHeart className="text-xl text-gray-500" />
+        <span className="text-gray-600">{interestCount}명</span>
+        <Button type="button" className="flex-[2] h-full" color="cheeseYellow">
+          경매로 전환하기
+        </Button>
+      </div>
+    );
+  }
+
+  return null;
+};
+
+export default SellersFooter;

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -23,5 +23,6 @@ export const API_END_POINT = {
   MY_ACUTION_PRE_ENROLL_REGISTER: 'api/v1/products/users',
   DEADLINE: '/products/deadline',
   PRE_ENROLL: '/products/pre_enroll',
-  DETAILS: '/auctions',
+  AUCTION_ITEM: 'api/v1/auctions/auction/:auctionId',
+  PRE_AUCTION_ITEM: 'api/v1/pre-auction/:auctionId',
 };

--- a/src/constants/route.ts
+++ b/src/constants/route.ts
@@ -18,10 +18,10 @@ const ROUTERS = Object.freeze({
   },
   REGISTER: '/auctions/register',
   AUCTION: {
-    ITEM: '/auctions/auction/:auctionId',
+    ITEM: '/auctions/auction',
   },
   PRE_AUCTION: {
-    ITEM: '/auctions/pre-auction/:auctionId',
+    ITEM: '/auctions/pre-auction',
   },
 
   ADDRESSBOOK: '/addressbook',

--- a/src/hooks/useFormatTime.ts
+++ b/src/hooks/useFormatTime.ts
@@ -1,0 +1,8 @@
+export const useFormatTime = (timeLeft: number) => {
+  const h = Math.floor(timeLeft / 3600);
+  const m = Math.floor((timeLeft % 3600) / 60);
+  const s = Math.floor(timeLeft % 60);
+  return `${h.toString().padStart(2, '0')}:${m
+    .toString()
+    .padStart(2, '0')}:${s.toString().padStart(2, '0')}`;
+};

--- a/src/hooks/useProgress.ts
+++ b/src/hooks/useProgress.ts
@@ -1,83 +1,22 @@
-// useProgress.ts
-// import { useState, useEffect } from 'react';
+import { useFormatTime } from '@/hooks/useFormatTime';
 
-// export const useProgress = (auctionStartTime: number, serverCurrentTime: number, totalTime: number) => {
-//   const elapsedTime = serverCurrentTime - auctionStartTime;
-//   const initialTimeLeft = totalTime - elapsedTime;
-//   const [timeLeft, setTimeLeft] = useState(initialTimeLeft > 0 ? initialTimeLeft : 0);
-
-//   useEffect(() => {
-//     const timer = setInterval(() => {
-//       setTimeLeft((prev) => (prev > 0 ? prev - 1 : 0));
-//     }, 1000);
-
-//     return () => clearInterval(timer);
-//   }, []);
-
-//   const formatTime = () => {
-//     const h = Math.floor(timeLeft / 3600);
-//     const m = Math.floor((timeLeft % 3600) / 60);
-//     const s = timeLeft % 60;
-//     return `${h.toString().padStart(2, '0')}:${m
-//       .toString()
-//       .padStart(2, '0')}:${s.toString().padStart(2, '0')}`;
-//   };
-
-//   const progressBarWidth = (timeLeft / totalTime) * 100;
-
-//   return { timeLeft, formatTime, progressBarWidth };
-// };
-
-import { useState, useEffect } from 'react';
-
-export const useProgress = (
+export function useProgress(
   auctionStartTime: number,
   serverCurrentTime: number,
   totalTime: number,
-) => {
-  const randomScenario = Math.floor(Math.random() * 3);
+  isLoading: boolean,
+) {
+  // 서버 현재 시간과 경매 시작 시간의 차이를 사용해 경과 시간을 계산
+  const elapsedTime = serverCurrentTime - auctionStartTime;
 
-  let elapsedTime;
-  switch (randomScenario) {
-    case 0: // 경매 시작한지 1시간 미만일 경우
-      elapsedTime = Math.floor(Math.random() * 3600);
-      break;
-    case 1: // 경매 시작한지 12시간이 넘었을 경우
-      elapsedTime = 12 * 3600 + Math.floor(Math.random() * (12 * 3600));
-      break;
-    case 2: // 경매 종료까지 2시간 남았을 경우
-      elapsedTime =
-        totalTime - 2 * 3600 + Math.floor(Math.random() * (2 * 3600));
-      break;
-    default:
-      elapsedTime = 0;
-  }
+  // 경매가 아직 시작되지 않았으면 경매 대기 상태로 표시
+  const initialTimeLeft = elapsedTime < 0 ? totalTime : totalTime - elapsedTime;
+  const timeLeft = initialTimeLeft > 0 ? initialTimeLeft : 0;
 
-  const adjustedServerCurrentTime = auctionStartTime + elapsedTime;
-  const initialTimeLeft =
-    totalTime - (adjustedServerCurrentTime - auctionStartTime);
-  const [timeLeft, setTimeLeft] = useState(
-    initialTimeLeft > 0 ? initialTimeLeft : 0,
-  );
+  // progress bar width 계산
+  const progressBarWidth = elapsedTime < 0 ? 0 : (timeLeft / totalTime) * 100;
 
-  useEffect(() => {
-    const timer = setInterval(() => {
-      setTimeLeft((prev) => (prev > 0 ? prev - 10 : 0)); // 1초에 10초씩 감소
-    }, 100);
+  const formattedTime = useFormatTime(timeLeft);
 
-    return () => clearInterval(timer);
-  }, []);
-
-  const formatTime = () => {
-    const h = Math.floor(timeLeft / 3600);
-    const m = Math.floor((timeLeft % 3600) / 60);
-    const s = timeLeft % 60;
-    return `${h.toString().padStart(2, '0')}:${m
-      .toString()
-      .padStart(2, '0')}:${s.toString().padStart(2, '0')}`;
-  };
-
-  const progressBarWidth = (timeLeft / totalTime) * 100;
-
-  return { timeLeft, formatTime, progressBarWidth };
-};
+  return { formattedTime, progressBarWidth, isLoading };
+}

--- a/src/mocks/broswer.ts
+++ b/src/mocks/broswer.ts
@@ -21,6 +21,7 @@ import { getOngoingProductList } from './handlers/ProductList';
 import postSignup from './handlers/Login';
 import { productDetailsHandler } from './handlers/productDetails';
 import { realTimeNotificationsHandler } from './handlers/realTimeNotification';
+import { auctionDetailPage } from './handlers/auctionDetailPage';
 
 /* eslint-disable import/no-named-as-default */
 export const handlers: HttpHandler[] = [
@@ -38,6 +39,7 @@ export const handlers: HttpHandler[] = [
   preRegisterHeartHandler,
   preRegisterHeartDeleteHandler,
   bidderListHandler,
+  auctionDetailPage,
 ];
 
 export const worker = setupWorker(...handlers);

--- a/src/mocks/data/auctionDetailPageData.ts
+++ b/src/mocks/data/auctionDetailPageData.ts
@@ -219,6 +219,46 @@ const auctionDetailPageData: AuctionItem[] = [
       'https://cdn.mos.cms.futurecdn.net/pARvMxPaaNixzABa2DgEXg.jpg',
     ],
   },
+  {
+    productId: 12,
+    sellerId: 12,
+    sellerName: 'User12',
+    title: 'Samsung Galaxy Z Fold 5',
+    description:
+      'Next-gen foldable smartphone with a large display and enhanced productivity features.',
+    minPrice: 1800000, // 현실적인 스마트폰 가격 (약 180만원)
+    endDateTime: generateRandomEndDateTime(),
+    status: 'PENDING',
+    isSeller: false,
+    participantCount: 0,
+    isParticipating: false,
+    bidAmount: 0,
+    remainingBidCount: 5,
+    imageList: [
+      'https://images.samsung.com/is/image/samsung/p6pim/levant/galaxy-z-fold5/f946/sm-f946bzbgeux/gallery/levant-galaxy-z-fold5-f946-470140-sm-f946bzbgeux-621237687?$2052_1641_PNG$',
+      'https://cdn.mos.cms.futurecdn.net/kek8nDAzj5P9Kv2TuVpDWg.jpg',
+    ],
+  },
+  {
+    productId: 13,
+    sellerId: 13,
+    sellerName: 'User13',
+    title: 'Sony A7 IV Mirrorless Camera',
+    description:
+      'High-performance mirrorless camera with advanced image processing and 33MP full-frame sensor.',
+    minPrice: 3000000, // 현실적인 카메라 가격 (약 300만원)
+    endDateTime: generateRandomEndDateTime(),
+    status: 'PENDING',
+    isSeller: true,
+    participantCount: 0,
+    isParticipating: false,
+    bidAmount: 0,
+    remainingBidCount: 3,
+    imageList: [
+      'https://www.sony.com/image/4f4c92321d8b3bbdcb6ad7b272b6ebd0?fmt=pjpeg&wid=330&bgcolor=FFFFFF&bgc=FFFFFF',
+      'https://cdn.mos.cms.futurecdn.net/dxt1Xp5tTp9ZG9NcdGLkB7.jpg',
+    ],
+  },
 ];
 
 export default auctionDetailPageData;

--- a/src/mocks/data/auctionDetailPageData.ts
+++ b/src/mocks/data/auctionDetailPageData.ts
@@ -1,0 +1,224 @@
+export interface AuctionItem {
+  productId: number;
+  sellerId: number;
+  sellerName: string;
+  title: string;
+  description: string;
+  minPrice: number;
+  endDateTime: string;
+  status: string;
+  isSeller: boolean;
+  participantCount: number;
+  isParticipating: boolean;
+  bidAmount: number;
+  remainingBidCount: number;
+  imageList: string[];
+}
+
+const generateRandomEndDateTime = (): string => {
+  const currentTimeInSeconds = Math.floor(Date.now() / 1000); // 현재 시간을 초 단위로 변환
+  const minTime = 0; // 최소 0초
+  const maxTime = 25 * 60 * 60; // 최대 25시간 (초 단위)
+  const randomTimeOffset =
+    Math.floor(Math.random() * (maxTime - minTime + 1)) + minTime;
+  return String(currentTimeInSeconds + randomTimeOffset); // 현재 시간 + 랜덤 오프셋
+};
+
+const auctionDetailPageData: AuctionItem[] = [
+  {
+    productId: 2,
+    sellerId: 2,
+    sellerName: 'User2',
+    title: 'Apple iPhone 13',
+    description: 'Latest Apple iPhone 13 with A15 Bionic chip.',
+    minPrice: 120000,
+    endDateTime: generateRandomEndDateTime(),
+    status: 'PROCEEDING',
+    isSeller: false,
+    participantCount: 10,
+    isParticipating: true,
+    bidAmount: 1300,
+    remainingBidCount: 2,
+    imageList: [
+      'https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/iphone-13-mini-finish-select-2021?wid=940&hei=1112&fmt=png-alpha&.v=1629928407000',
+      'https://cdn.mos.cms.futurecdn.net/2cYrKLpEFsbXfR67VvXhMi.jpg',
+    ],
+  },
+  {
+    productId: 3,
+    sellerId: 3,
+    sellerName: 'User3',
+    title: 'Sony PlayStation 5',
+    description: 'Next-generation PlayStation console for immersive gaming.',
+    minPrice: 500000,
+    endDateTime: generateRandomEndDateTime(),
+    status: 'PROCEEDING',
+    isSeller: true,
+    participantCount: 20,
+    isParticipating: false,
+    bidAmount: 0,
+    remainingBidCount: 3,
+    imageList: [
+      'https://cdn.mos.cms.futurecdn.net/FPCZfAygn7CB7NZBszr2tW.jpg',
+      'https://cdn.vox-cdn.com/thumbor/EiW5q8kx_Z7sk3DJ9CmBdKP5Dws=/1400x1400/filters:format(jpeg)/cdn.vox-cdn.com/uploads/chorus_asset/file/22211366/vpavic_4278_20201023_0044.jpg',
+    ],
+  },
+  {
+    productId: 4,
+    sellerId: 4,
+    sellerName: 'User4',
+    title: 'Samsung Galaxy S22',
+    description: 'Flagship smartphone from Samsung with powerful features.',
+    minPrice: 900,
+    endDateTime: generateRandomEndDateTime(),
+    status: 'PROCEEDING',
+    isSeller: false,
+    participantCount: 15,
+    isParticipating: true,
+    bidAmount: 950,
+    remainingBidCount: 1,
+    imageList: [
+      'https://images.samsung.com/is/image/samsung/p6pim/in/2202/gallery/in-galaxy-s22-s901-sm-s901elvdinu-530086852?$1300_1038_PNG$',
+      'https://www.gizmochina.com/wp-content/uploads/2022/03/Samsung-Galaxy-S22-Featured-768x768.jpg',
+    ],
+  },
+  {
+    productId: 5,
+    sellerId: 5,
+    sellerName: 'User5',
+    title: 'Apple MacBook Air M2',
+    description:
+      'Thin and light laptop with Apple M2 chip for amazing performance.',
+    minPrice: 1500,
+    endDateTime: generateRandomEndDateTime(),
+    status: 'PROCEEDING',
+    isSeller: true,
+    participantCount: 8,
+    isParticipating: true,
+    bidAmount: 1600,
+    remainingBidCount: 2,
+    imageList: [
+      'https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/mb-air-m2-silver-select-202206_GEO_EMEA_LANG_EN?wid=904&hei=840&fmt=jpeg&qlt=90&.v=1653497304015',
+      'https://cdn.mos.cms.futurecdn.net/PKqNqNRT6gV5AeosFGuh7V.jpg',
+    ],
+  },
+  {
+    productId: 6,
+    sellerId: 6,
+    sellerName: 'User6',
+    title: 'Bose QuietComfort 45 Headphones',
+    description: 'Noise-cancelling headphones for immersive audio experience.',
+    minPrice: 350,
+    endDateTime: generateRandomEndDateTime(),
+    status: 'PROCEEDING',
+    isSeller: false,
+    participantCount: 5,
+    isParticipating: true,
+    bidAmount: 370,
+    remainingBidCount: 1,
+    imageList: [
+      'https://assets.bose.com/content/dam/Bose_DAM/Web/consumer_electronics/global/products/headphones/quietcomfort_45/product_silo_images/qc45_b_lg_01.png/_jcr_content/renditions/cq5dam.web.320.320.png',
+      'https://cdn.mos.cms.futurecdn.net/B9PC6XMwqxxFmSh2KL2qJm.jpg',
+    ],
+  },
+  {
+    productId: 7,
+    sellerId: 7,
+    sellerName: 'User7',
+    title: 'Nintendo Switch OLED',
+    description:
+      'Enhanced Nintendo Switch with OLED display for vivid visuals.',
+    minPrice: 400,
+    endDateTime: generateRandomEndDateTime(),
+    status: 'PROCEEDING',
+    isSeller: true,
+    participantCount: 12,
+    isParticipating: true,
+    bidAmount: 420,
+    remainingBidCount: 2,
+    imageList: [
+      'https://assets.nintendo.com/image/upload/f_auto/q_auto/dpr_auto/c_scale,w_300/ncom/en_US/switch/console/oled-model-gallery/screenshot01',
+      'https://cdn.vox-cdn.com/thumbor/wz7g4TBOO24MylZK7ozKf1foOS8=/1400x1400/filters:format(jpeg)/cdn.vox-cdn.com/uploads/chorus_asset/file/22344038/akrales_210708_4640_0085.jpg',
+    ],
+  },
+  {
+    productId: 8,
+    sellerId: 8,
+    sellerName: 'User8',
+    title: 'Dyson V15 Detect Vacuum Cleaner',
+    description: 'Powerful cordless vacuum cleaner with laser dust detection.',
+    minPrice: 600,
+    endDateTime: generateRandomEndDateTime(),
+    status: 'PROCEEDING',
+    isSeller: false,
+    participantCount: 6,
+    isParticipating: true,
+    bidAmount: 620,
+    remainingBidCount: 2,
+    imageList: [
+      'https://dyson-h.assetsadobe.com/is/image/content/dam/dyson/images/products/primary/368346-01.png?$responsive$&cropPathE=desktop&fit=stretch,1&wid=1920',
+      'https://cdn.mos.cms.futurecdn.net/U23zytA3foXAFJAs2ntSPf.jpg',
+    ],
+  },
+  {
+    productId: 9,
+    sellerId: 9,
+    sellerName: 'User9',
+    title: 'Sony WH-1000XM4 Headphones',
+    description:
+      'Industry-leading noise cancellation with superior sound quality.',
+    minPrice: 350,
+    endDateTime: generateRandomEndDateTime(),
+    status: 'PROCEEDING',
+    isSeller: false,
+    participantCount: 5,
+    isParticipating: true,
+    bidAmount: 370,
+    remainingBidCount: 2,
+    imageList: [
+      'https://cdn.sony-asia.com/image/ed4aa1535f9eb0e49a482d2ad24a823f?fmt=pjpeg&wid=330&bgcolor=FFFFFF&bgc=FFFFFF',
+      'https://cdn.mos.cms.futurecdn.net/YgzWQoTcTbmw2Q7V3SMiPA.jpg',
+    ],
+  },
+  {
+    productId: 10,
+    sellerId: 10,
+    sellerName: 'User10',
+    title: 'Apple Watch Series 7',
+    description:
+      'Smartwatch with a larger, always-on display and advanced features.',
+    minPrice: 450000,
+    endDateTime: generateRandomEndDateTime(),
+    status: 'PROCEEDING',
+    isSeller: true,
+    participantCount: 8,
+    isParticipating: false,
+    bidAmount: 0,
+    remainingBidCount: 3,
+    imageList: [
+      'https://cdsassets.apple.com/live/SZLF0YNV/images/sp/111909_series7-480.png',
+      'https://cdn.mos.cms.futurecdn.net/gpBKRvs9nTpFrVsnG8mxkP.jpg',
+    ],
+  },
+  {
+    productId: 11,
+    sellerId: 11,
+    sellerName: 'User11',
+    title: 'GoPro HERO10 Black',
+    description: 'Action camera with incredible video quality and performance.',
+    minPrice: 400000,
+    endDateTime: generateRandomEndDateTime(),
+    status: 'PROCEEDING',
+    isSeller: true,
+    participantCount: 7,
+    isParticipating: true,
+    bidAmount: 530,
+    remainingBidCount: 2,
+    imageList: [
+      'https://gopro.com/content/dam/gopro/corporate/website-hotspot/global/hero10/features/hero10-feature-1-superphoto.jpg',
+      'https://cdn.mos.cms.futurecdn.net/pARvMxPaaNixzABa2DgEXg.jpg',
+    ],
+  },
+];
+
+export default auctionDetailPageData;

--- a/src/mocks/handlers/auctionDetailPage.ts
+++ b/src/mocks/handlers/auctionDetailPage.ts
@@ -1,0 +1,19 @@
+import { http, HttpResponse, HttpHandler } from 'msw';
+import { API_END_POINT } from '@/constants/api';
+import auctionDetailPageData from '../data/auctionDetailPageData';
+
+const data = [...auctionDetailPageData];
+
+export const auctionDetailPage: HttpHandler = http.get(
+  API_END_POINT.AUCTION_ITEM,
+  ({ params }) => {
+    const foundAuction = data.find(
+      (auction) => auction.productId === Number(params.auctionId),
+    );
+    const auctionData = foundAuction || null; // Assign auction to auctionData if found
+    return HttpResponse.json({
+      auctionData,
+      message: 'success',
+    });
+  },
+);

--- a/src/pages/DetailPage.tsx
+++ b/src/pages/DetailPage.tsx
@@ -3,10 +3,12 @@ import { useEffect, useState } from 'react';
 import JordanBlue from '@/assets/images/jordan_blue.jpeg';
 import Layout from '@/components/layout/Layout';
 import ProgressBar from '@/components/details/ProgressBar';
-
 import { useNavigate } from 'react-router-dom';
 import { useProgress } from '@/hooks/useProgress';
 import Button from '@/components/common/Button';
+import { CiCoins1 } from 'react-icons/ci';
+import Participants from '@/assets/icons/participants.svg';
+import Price from '@/assets/icons/price.svg';
 
 const Details = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -101,7 +103,10 @@ const Details = () => {
               <p className="text-lg font-bold mb-1">[나이키] 신발</p>
               <p className="text-sm text-gray-500">
                 <span className="inline-flex items-center">
-                  <span className="mr-1">💎</span> 시작가{' '}
+                  <span className="mr-1">
+                    <img src={Price} alt="Price" />
+                  </span>
+                  시작가
                   <span className="font-bold">10,000,000원</span>
                 </span>
               </p>
@@ -110,13 +115,23 @@ const Details = () => {
             {/* 나의 참여 금액 & 경매 참여인원 */}
             <div className="w-full mb-4 border border-gray-300 rounded-lg">
               <div className="flex items-center justify-between">
-                <div className="text-center flex-1 py-4">
-                  <p className="text-sm text-gray-500 mb-1">나의 참여 금액</p>
-                  <p className="text-lg font-bold">참여 전</p>
+                <div className="flex flex-col items-center text-center flex-1 py-4">
+                  <div className="flex items-center text-sm text-gray-400 mb-1">
+                    <CiCoins1 className="text-xl mx-1" />
+                    <span className="ml-1">나의 참여 금액</span>
+                  </div>
+                  <p className="text-xl font-bold text-gray-800">참여 전</p>
                 </div>
                 <div className="border-l border-gray-300 h-full" />
-                <div className="text-center flex-1 py-4">
-                  <p className="text-sm text-gray-500 mb-1">참여 인원</p>
+                <div className="flex flex-col items-center text-center flex-1 py-4">
+                  <div className="flex items-center text-sm text-gray-400 mb-1">
+                    <img
+                      src={Participants}
+                      alt="Participants"
+                      className="w-4 h-4 mx-2 mb-1"
+                    />
+                    <p className="text-sm text-gray-500 mb-1">참여 인원</p>
+                  </div>
                   <p className="text-lg font-bold">55명</p>
                 </div>
               </div>

--- a/src/pages/DetailPage.tsx
+++ b/src/pages/DetailPage.tsx
@@ -3,28 +3,29 @@ import { useEffect, useState } from 'react';
 import JordanBlue from '@/assets/images/jordan_blue.jpeg';
 import Layout from '@/components/layout/Layout';
 import ProgressBar from '@/components/details/ProgressBar';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { useProgress } from '@/hooks/useProgress';
 import Button from '@/components/common/Button';
 import { CiCoins1 } from 'react-icons/ci';
 import Participants from '@/assets/icons/participants.svg';
 import Price from '@/assets/icons/price.svg';
+import axios from 'axios';
+import { API_END_POINT } from '@/constants/api';
+import type { AuctionItem } from '@/mocks/data/auctionDetailPageData';
 
 const Details = () => {
+  const { productId } = useParams() as { productId: string }; // URL에서 productId 가져오기
+  const [auctionItem, setAuctionItem] = useState<AuctionItem | null>(null); // 경매 데이터를 저장할 상태
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
   const [isTimerFixed, setIsTimerFixed] = useState(false);
+  const [isPreAuction, setIsPreAuction] = useState(false);
+  const [interestCount, setInterestCount] = useState(1);
+  const [serverCurrentTime, setServerCurrentTime] = useState(
+    Math.floor(Date.now() / 1000),
+  ); // 서버 시간 예시
 
-  const totalTime = 24 * 60 * 60; // 24시간을 초로 변환
-  const auctionStartTime = 1627880400; // 예시: 서버로부터 전달받은 경매 시작 시간 (초 단위 타임스탬프)
-  const serverCurrentTime = Math.floor(Date.now() / 1000); // 예시: 현재 서버 시간 (초 단위 타임스탬프)
-  const [isPreAuction, setIsPreAuction] = useState(false); // 사전경매 등록여부 초기값을 false로 설정
-  const [interestCount, setInterestCount] = useState(1); // 관심을 가진 사람들의 수
-
-  const { formatTime, progressBarWidth } = useProgress(
-    auctionStartTime,
-    serverCurrentTime,
-    totalTime,
-  );
+  const totalTime = 24 * 60 * 60;
 
   const navigate = useNavigate();
   const handleBackClick = () => {
@@ -39,30 +40,41 @@ const Details = () => {
     setIsMenuOpen(false);
   };
 
+  const { formattedTime, progressBarWidth } = useProgress(
+    Number(auctionItem?.endDateTime) - 86400,
+    serverCurrentTime,
+    totalTime,
+    isLoading,
+  );
+
+  // 세자리 단위로 콤마를 찍어주는 함수
+  const numberWithCommas = (x: number) => {
+    return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+  };
+
   useEffect(() => {
-    // 페이지가 로드될 때 한 번만 실행
-    const randomPreAuction = Math.random() < 0.5;
-    const randomInterestCount = Math.floor(Math.random() * 100);
-    setIsPreAuction(randomPreAuction); // true 또는 false 랜덤 결정
-    setInterestCount(randomInterestCount); // 0에서 99 사이의 랜덤 숫자
-
-    const handleScroll = () => {
-      const scrollTop =
-        window.pageYOffset || document.documentElement.scrollTop;
-      const timerElement = document.getElementById('timer-section');
-      if (timerElement) {
-        const { offsetTop } = timerElement;
-
-        if (scrollTop > offsetTop) {
-          setIsTimerFixed(true);
-        } else {
-          setIsTimerFixed(false);
-        }
+    const fetchData = async () => {
+      try {
+        const response = await axios.get(
+          `api/v1/auctions/auction/${productId}`,
+        );
+        console.log(response.data);
+        setAuctionItem(response.data.auctionData);
+      } catch (error) {
+        console.error(error);
+        alert('경매 데이터를 가져오는 중 오류가 발생했습니다.');
       }
     };
+    fetchData();
+    setIsLoading(false);
+  }, [productId]);
 
-    window.addEventListener('scroll', handleScroll);
-    return () => window.removeEventListener('scroll', handleScroll);
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setServerCurrentTime(Math.floor(Date.now() / 1000));
+    }, 1000);
+
+    return () => clearInterval(interval);
   }, []);
 
   return (
@@ -83,34 +95,48 @@ const Details = () => {
               />
             </div>
             {/* 타이머 및 프로그레스 바 */}
-            <div
-              id="timer-section"
-              className={`${
-                isTimerFixed ? 'fixed top-0 left-0 right-0' : ''
-              } bg-white z-10 py-1 border-b border-gray-300`} // Reduced padding on y-axis
-            >
-              <div className="text-lg font-bold text-center text-green-500">
-                {formatTime()}
+            {auctionItem && (
+              <div
+                id="timer-section"
+                className={`bg-white z-10 py-1 ${isTimerFixed ? 'fixed top-0 left-0 right-0' : ''}`}
+              >
+                {isLoading ? (
+                  <div className="text-center text-gray-500 font-bold">
+                    로딩 중...
+                  </div>
+                ) : (
+                  <ProgressBar
+                    auctionStartTime={Number(auctionItem?.endDateTime) - 86400}
+                    serverCurrentTime={serverCurrentTime}
+                    totalTime={totalTime}
+                    isLoading={isLoading}
+                  />
+                )}
               </div>
-              <ProgressBar progressBarWidth={progressBarWidth} />
-            </div>
+            )}
           </div>
 
           {/* 경매 정보 영역 */}
           <div className="px-4 my-4">
             {/* 경매 아이템 제목 & 시작가 */}
-            <div className="mb-4">
-              <p className="text-lg font-bold mb-1">[나이키] 신발</p>
-              <p className="text-sm text-gray-500">
-                <span className="inline-flex items-center">
-                  <span className="mr-1">
-                    <img src={Price} alt="Price" />
+            {auctionItem && (
+              <div className="mb-4">
+                <p className="text-lg font-bold mb-1">
+                  {auctionItem.title || ''}
+                </p>
+                <p className="text-sm text-gray-500">
+                  <span className="inline-flex items-center">
+                    <span className="mr-1">
+                      <img src={Price} alt="Price" />
+                    </span>
+                    시작가
+                    <span className="font-bold p">
+                      {numberWithCommas(Number(auctionItem.minPrice))}원
+                    </span>
                   </span>
-                  시작가
-                  <span className="font-bold">10,000,000원</span>
-                </span>
-              </p>
-            </div>
+                </p>
+              </div>
+            )}
 
             {/* 나의 참여 금액 & 경매 참여인원 */}
             <div className="w-full mb-4 border border-gray-300 rounded-lg">
@@ -120,7 +146,11 @@ const Details = () => {
                     <CiCoins1 className="text-xl mx-1" />
                     <span className="ml-1">나의 참여 금액</span>
                   </div>
-                  <p className="text-xl font-bold text-gray-800">참여 전</p>
+                  <p className="text-xl font-bold text-gray-800">
+                    {auctionItem?.isParticipating
+                      ? `${numberWithCommas(Number(auctionItem.bidAmount))}원`
+                      : '참여 전'}
+                  </p>
                 </div>
                 <div className="border-l border-gray-300 h-full" />
                 <div className="flex flex-col items-center text-center flex-1 py-4">
@@ -132,7 +162,11 @@ const Details = () => {
                     />
                     <p className="text-sm text-gray-500 mb-1">참여 인원</p>
                   </div>
-                  <p className="text-lg font-bold">55명</p>
+                  <p className="text-lg font-bold">
+                    {auctionItem?.participantCount
+                      ? `${auctionItem.participantCount}명`
+                      : ''}
+                  </p>
                 </div>
               </div>
             </div>
@@ -140,104 +174,7 @@ const Details = () => {
 
           {/* 상품 설명 */}
           <div className="px-4 mb-4 overflow-y-auto text-sm text-gray-700">
-            <p className="mb-2">
-              Air Jordan 1 Retro High OG는 마이클 조던(Michael Jordan)이 1985년
-              NBA 농구 시즌에서 신은 초기 디자인을 재현한 스니커즈입니다. 이
-              신발은 고급 품질의 가죽과 트라이플 스티치가 특징인 전통적인 형태를
-              갖추고 있습니다. 클래식한 실루엣과 현대적인 소재를 결합하여,
-              어디에서나 주목받을 수 있는 디자인을 제공합니다. 이 제품은 농구
-              코트뿐만 아니라 일상 생활에서도 착용하기 좋습니다.
-            </p>
-            <p className="mb-2">
-              Air Jordan 1 Retro High OG는 시대를 초월한 스타일과 우수한
-              내구성으로 유명합니다. 이 신발의 고급 가죽은 시간이 지남에 따라 더
-              멋진 외관을 유지하며, 트라이플 스티치는 오랜 사용에도 견고함을
-              제공합니다. Jordan 브랜드의 아이코닉한 윙 로고와 Nike Air 쿠셔닝
-              시스템은 이 신발을 더욱 특별하게 만듭니다. 이는 패션과 기능성을
-              모두 갖춘 신발로, 어떤 옷차림에도 잘 어울립니다.
-            </p>
-            <p className="mb-2">
-              Michael Jordan이 처음으로 착용한 Air Jordan 1은 농구 역사에서 가장
-              중요한 신발 중 하나로 간주됩니다. 이 신발은 많은 사람들에게 영감을
-              주었으며, 농구 문화뿐만 아니라 스니커즈 문화를 혁신적으로
-              변화시켰습니다. Air Jordan 1 Retro High OG는 이 전설적인 신발의
-              원래 디자인을 충실하게 재현하였으며, 최신 기술과 결합하여 더 나은
-              편안함과 성능을 제공합니다. 이 신발은 당신의 스타일을 한층 더
-              업그레이드할 것입니다.
-            </p>
-            <p className="mb-2">
-              Jordan 1 Retro High OG는 다양한 컬러웨이로 제공되어 개인의 취향에
-              맞게 선택할 수 있습니다. 각 색상은 고유의 스토리를 가지고 있으며,
-              모두 Jordan 브랜드의 역사와 유산을 반영하고 있습니다. 이 신발은
-              한정판으로 출시되어 수집가들에게도 큰 인기를 끌고 있으며, 매년
-              새로운 버전이 출시됩니다. 이러한 이유로 Jordan 1 Retro High OG는
-              스니커즈 팬들에게 항상 사랑받는 아이템으로 자리 잡고 있습니다.
-            </p>
-            <p className="mb-2">
-              Air Jordan 1 Retro High OG는 최고급 소재와 장인 정신을 바탕으로
-              제작되었습니다. Nike의 기술력과 Jordan 브랜드의 유산이 결합된 이
-              신발은 높은 수준의 품질을 자랑합니다. 이 제품은 농구를 사랑하는
-              사람들뿐만 아니라, 스타일과 편안함을 중시하는 모든 이들에게 완벽한
-              선택이 될 것입니다. 언제 어디서나 돋보이는 신발을 찾고 있다면, Air
-              Jordan 1 Retro High OG가 그 답입니다.
-            </p>
-            <p className="mb-2">
-              마이클 조던의 전설적인 커리어와 함께한 Air Jordan 1은 NBA와
-              스니커즈 역사에서 없어서는 안 될 부분이 되었습니다. 이 신발은
-              단순한 패션 아이템을 넘어, 농구와 문화의 아이콘으로 자리
-              잡았습니다. Jordan 1 Retro High OG는 그 시절의 영광을 오늘날로
-              이어가고 있으며, 여전히 많은 사람들에게 사랑받고 있습니다. 당신이
-              이 신발을 신는 순간, 그 역사를 함께할 수 있을 것입니다.
-            </p>
-            <p className="mb-2">
-              Air Jordan 1 Retro High OG는 마이클 조던(Michael Jordan)이 1985년
-              NBA 농구 시즌에서 신은 초기 디자인을 재현한 스니커즈입니다. 이
-              신발은 고급 품질의 가죽과 트라이플 스티치가 특징인 전통적인 형태를
-              갖추고 있습니다. 클래식한 실루엣과 현대적인 소재를 결합하여,
-              어디에서나 주목받을 수 있는 디자인을 제공합니다. 이 제품은 농구
-              코트뿐만 아니라 일상 생활에서도 착용하기 좋습니다.
-            </p>
-            <p className="mb-2">
-              Air Jordan 1 Retro High OG는 시대를 초월한 스타일과 우수한
-              내구성으로 유명합니다. 이 신발의 고급 가죽은 시간이 지남에 따라 더
-              멋진 외관을 유지하며, 트라이플 스티치는 오랜 사용에도 견고함을
-              제공합니다. Jordan 브랜드의 아이코닉한 윙 로고와 Nike Air 쿠셔닝
-              시스템은 이 신발을 더욱 특별하게 만듭니다. 이는 패션과 기능성을
-              모두 갖춘 신발로, 어떤 옷차림에도 잘 어울립니다.
-            </p>
-            <p className="mb-2">
-              Michael Jordan이 처음으로 착용한 Air Jordan 1은 농구 역사에서 가장
-              중요한 신발 중 하나로 간주됩니다. 이 신발은 많은 사람들에게 영감을
-              주었으며, 농구 문화뿐만 아니라 스니커즈 문화를 혁신적으로
-              변화시켰습니다. Air Jordan 1 Retro High OG는 이 전설적인 신발의
-              원래 디자인을 충실하게 재현하였으며, 최신 기술과 결합하여 더 나은
-              편안함과 성능을 제공합니다. 이 신발은 당신의 스타일을 한층 더
-              업그레이드할 것입니다.
-            </p>
-            <p className="mb-2">
-              Jordan 1 Retro High OG는 다양한 컬러웨이로 제공되어 개인의 취향에
-              맞게 선택할 수 있습니다. 각 색상은 고유의 스토리를 가지고 있으며,
-              모두 Jordan 브랜드의 역사와 유산을 반영하고 있습니다. 이 신발은
-              한정판으로 출시되어 수집가들에게도 큰 인기를 끌고 있으며, 매년
-              새로운 버전이 출시됩니다. 이러한 이유로 Jordan 1 Retro High OG는
-              스니커즈 팬들에게 항상 사랑받는 아이템으로 자리 잡고 있습니다.
-            </p>
-            <p className="mb-2">
-              Air Jordan 1 Retro High OG는 최고급 소재와 장인 정신을 바탕으로
-              제작되었습니다. Nike의 기술력과 Jordan 브랜드의 유산이 결합된 이
-              신발은 높은 수준의 품질을 자랑합니다. 이 제품은 농구를 사랑하는
-              사람들뿐만 아니라, 스타일과 편안함을 중시하는 모든 이들에게 완벽한
-              선택이 될 것입니다. 언제 어디서나 돋보이는 신발을 찾고 있다면, Air
-              Jordan 1 Retro High OG가 그 답입니다.
-            </p>
-            <p className="mb-2">
-              마이클 조던의 전설적인 커리어와 함께한 Air Jordan 1은 NBA와
-              스니커즈 역사에서 없어서는 안 될 부분이 되었습니다. 이 신발은
-              단순한 패션 아이템을 넘어, 농구와 문화의 아이콘으로 자리
-              잡았습니다. Jordan 1 Retro High OG는 그 시절의 영광을 오늘날로
-              이어가고 있으며, 여전히 많은 사람들에게 사랑받고 있습니다. 당신이
-              이 신발을 신는 순간, 그 역사를 함께할 수 있을 것입니다.
-            </p>
+            <p>{auctionItem?.description}</p>
           </div>
         </Layout.Main>
         {/* 화면 하단에 고정된 Footer */}

--- a/src/pages/DetailPage.tsx
+++ b/src/pages/DetailPage.tsx
@@ -1,16 +1,14 @@
-import { AiOutlineHeart } from 'react-icons/ai';
 import { useEffect, useState } from 'react';
-import JordanBlue from '@/assets/images/jordan_blue.jpeg';
 import Layout from '@/components/layout/Layout';
 import ProgressBar from '@/components/details/ProgressBar';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useProgress } from '@/hooks/useProgress';
-import Button from '@/components/common/Button';
 import { CiCoins1 } from 'react-icons/ci';
 import Participants from '@/assets/icons/participants.svg';
 import Price from '@/assets/icons/price.svg';
 import axios from 'axios';
-import { API_END_POINT } from '@/constants/api';
+import SellersFooter from '@/components/details/SellersFooter';
+import BuyersFooter from '@/components/details/BuyersFooter';
 import type { AuctionItem } from '@/mocks/data/auctionDetailPageData';
 
 const Details = () => {
@@ -40,7 +38,7 @@ const Details = () => {
     setIsMenuOpen(false);
   };
 
-  const { formattedTime, progressBarWidth } = useProgress(
+  useProgress(
     Number(auctionItem?.endDateTime) - 86400,
     serverCurrentTime,
     totalTime,
@@ -89,8 +87,8 @@ const Details = () => {
           <div className="relative w-full bg-yellow-300">
             <div className="w-full mb-2">
               <img
-                src={JordanBlue}
-                alt="Jordan Blue"
+                src={auctionItem?.imageList[0] || auctionItem?.title}
+                alt={auctionItem?.title}
                 className="object-cover w-full h-auto" // Ensures the image maintains its aspect ratio
               />
             </div>
@@ -179,28 +177,18 @@ const Details = () => {
         </Layout.Main>
         {/* 화면 하단에 고정된 Footer */}
         <Layout.Footer type={isPreAuction ? 'double' : 'single'}>
-          {isPreAuction ? (
-            <>
-              <div className="flex items-center flex-1 h-full gap-2">
-                <AiOutlineHeart className="text-xl text-gray-500" />
-                <span className="text-gray-600">{interestCount}명</span>
-              </div>
-              <Button
-                type="button"
-                className="flex-[2] h-full"
-                color="cheeseYellow"
-              >
-                경매로 전환하기
-              </Button>
-            </>
+          {auctionItem && auctionItem.isSeller ? (
+            <SellersFooter
+              isSeller={auctionItem.isSeller}
+              status={auctionItem.status}
+            />
           ) : (
-            <Button
-              type="button"
-              className="w-full h-full"
-              color="cheeseYellow"
-            >
-              경매 참여하기
-            </Button>
+            <BuyersFooter
+              isSeller={auctionItem?.isSeller ?? false}
+              status={auctionItem?.status ?? ''}
+              isParticipating={auctionItem?.isParticipating ?? false}
+              remainingBidCount={auctionItem?.remainingBidCount ?? 0}
+            />
           )}
         </Layout.Footer>
         {/* 백드롭 */}

--- a/src/routing.tsx
+++ b/src/routing.tsx
@@ -83,7 +83,7 @@ const routeList = [
         element: <Login />,
       },
       {
-        path: ROUTERS.AUCTION.ITEM,
+        path: `${ROUTERS.AUCTION.ITEM}/:productId`,
         element: <DetailPage />,
       },
       {


### PR DESCRIPTION
## 💡 작업 내용

- [x] api 명세에 맞게 더미 데이터 생성
- [x] msw 핸들러 생성
- [x] api 명세에 맞게 데이터 fecthing 변경
- [x] 하드코딩된 랜더링 코드 수정
- [x] 판매자/구매자 상태에 따른 footer 변경
- [x] 경매의 상태에 따른 footer 변경

## 💡 자세한 설명

1. api 명세에 맞게 더미 데이터를 만들고 fecthing할 수 있도록 하였습니다
2. 그리고 해당 데이터를 받아서 실제 서비스처럼 랜더링 되도록 하드코딩 된 부분을 수정했습니다
3. 판매자/구매자에 따라서 보여지는 footer 버튼이 달라지도록 수정했습니다.
4. 판매자일 경우 사전경매 등록 상태 / 실 경매상태에 따라서 '경매로 전환하기' / '내가 올린 경매입니다' 문구와 버튼이 노출되도록
수정했습니다
5. 구매자일 경우 경매 물픔의 상태(사전경매 or 실경매) 및 구매자가 경매에 참여할 경우, 가격 제시 횟수가 소진되었을 경우, 경매가 종료되었을 경우에 따라서 footer 형태가 바뀌도록 수정했습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [ ] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [ ] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 테스트는 잘 통과했나요?
- [ ] 불필요한 코드는 제거했나요?

closes #이슈번호
