### PR TITLE
fix: sse refresh token 만료시 발생하는 error handling

### DIFF
--- a/src/hooks/useSSE.ts
+++ b/src/hooks/useSSE.ts
@@ -3,8 +3,9 @@ import { useEffect, useRef, useState } from 'react';
 
 import { getToken } from '@/utils/tokenUtils';
 import { isLoggedIn } from '@/store/authSlice';
-import { refreshToken } from '@/components/login/queries';
+import { logout, refreshToken } from '@/components/login/queries';
 import { useSelector } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
 
 export const useSSE = <T>(url: string) => {
   const [state, setState] = useState<T[]>([]);
@@ -12,6 +13,7 @@ export const useSSE = <T>(url: string) => {
   const eventSource = useRef<null | EventSource>(null);
   const accessToken = getToken();
   const isLogin = useSelector(isLoggedIn);
+  const navigate = useNavigate();
 
   useEffect(() => {
     const fetchSSE = () => {
@@ -23,12 +25,15 @@ export const useSSE = <T>(url: string) => {
         withCredentials: true,
       });
 
-      eventSource.current.onopen = () => {};
-
-      eventSource.current.onerror = () => {
-        refreshToken();
-        eventSource.current?.close();
-        setTimeout(fetchSSE, 3000);
+      eventSource.current.onerror = async () => {
+        try {
+          await refreshToken();
+          eventSource.current?.close();
+          setTimeout(fetchSSE, 3000);
+        } catch (error) {
+          await logout();
+          navigate('/login');
+        }
       };
 
       eventSource.current.addEventListener('notification', (e) => {


### PR DESCRIPTION
## 💡 작업 내용

- [x] refresh token이 만료되어 refreshToken function에서 throw한 error를 onerror 이벤트에서 try...catch로 캐치하여 사용자를 로그아웃 시키고 로그인페이지로 redirect시키고 재로그인을 유도한다.

## 💡 자세한 설명

SSE 에러가 발생하는 경우는 두 가지 경우이다.

첫 번째는 EventSourcePolyfill을 사용해서 default 45초 동안, 또는 서버와 합의해서 설정한 heartbeat(30분) 시간 동안 아무 요청이 없으면 연결을 끊어서 에러가 발생한다.
onerror 이벤트에서 연결을 close하고 3초뒤에 다시 재연결함으로써 error를 handling 한다.

두 번째는 이번에 해결하려는 재연결을 하는 과정에서 토큰이 만료되는 문제이다.
onerror 이벤트에서 재연결을 할 때 access token이 만료되거나 없으면 refreshToken function을 사용해서 쿠키에 담겨 있는 refresh token을 기반으로 access token을 재발급한다.
하지만 refresh token이 만료된 상황이라면 refreshToken function에서 error를 throw한다.
onerror 이벤트에서는 try...catch로 error를 캐치하여 사용자를 로그아웃 시키고 로그인페이지로 redirect시키고 재로그인을 유도한다.

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #95 
