### PR TITLE
Feature: 홈페이지, 경매 등록 이미지 캐러셀 적용

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@hookform/resolvers": "^3.9.0",
         "@radix-ui/react-select": "^2.1.1",
+        "@radix-ui/react-slot": "^1.1.0",
         "@reduxjs/toolkit": "^2.2.6",
         "@tanstack/react-query": "^5.51.11",
         "@tanstack/react-query-devtools": "^5.51.11",
@@ -19,6 +20,7 @@
         "classnames": "^2.5.1",
         "clsx": "^2.1.1",
         "dotenv": "^16.4.5",
+        "embla-carousel-react": "^8.3.0",
         "event-source-polyfill": "^1.0.31",
         "lucide-react": "^0.417.0",
         "msw": "^2.3.4",
@@ -3992,6 +3994,31 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.823.tgz",
       "integrity": "sha512-4h+oPeAiGQOHFyUJOqpoEcPj/xxlicxBzOErVeYVMMmAiXUXsGpsFd0QXBMaUUbnD8hhSfLf9uw+MlsoIA7j5w==",
       "dev": true
+    },
+    "node_modules/embla-carousel": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.3.0.tgz",
+      "integrity": "sha512-Ve8dhI4w28qBqR8J+aMtv7rLK89r1ZA5HocwFz6uMB/i5EiC7bGI7y+AM80yAVUJw3qqaZYK7clmZMUR8kM3UA=="
+    },
+    "node_modules/embla-carousel-react": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-react/-/embla-carousel-react-8.3.0.tgz",
+      "integrity": "sha512-P1FlinFDcIvggcErRjNuVqnUR8anyo8vLMIH8Rthgofw7Nj8qTguCa2QjFAbzxAUTQTPNNjNL7yt0BGGinVdFw==",
+      "dependencies": {
+        "embla-carousel": "8.3.0",
+        "embla-carousel-reactive-utils": "8.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.1 || ^18.0.0"
+      }
+    },
+    "node_modules/embla-carousel-reactive-utils": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-reactive-utils/-/embla-carousel-reactive-utils-8.3.0.tgz",
+      "integrity": "sha512-EYdhhJ302SC4Lmkx8GRsp0sjUhEN4WyFXPOk0kGu9OXZSRMmcBlRgTvHcq8eKJE1bXWBsOi1T83B+BSSVZSmwQ==",
+      "peerDependencies": {
+        "embla-carousel": "8.3.0"
+      }
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
     "@radix-ui/react-select": "^2.1.1",
+    "@radix-ui/react-slot": "^1.1.0",
     "@reduxjs/toolkit": "^2.2.6",
     "@tanstack/react-query": "^5.51.11",
     "@tanstack/react-query-devtools": "^5.51.11",
@@ -29,6 +30,7 @@
     "classnames": "^2.5.1",
     "clsx": "^2.1.1",
     "dotenv": "^16.4.5",
+    "embla-carousel-react": "^8.3.0",
     "event-source-polyfill": "^1.0.31",
     "lucide-react": "^0.417.0",
     "msw": "^2.3.4",

--- a/src/components/common/CustomCarousel.tsx
+++ b/src/components/common/CustomCarousel.tsx
@@ -1,0 +1,25 @@
+import { ReactNode } from 'react';
+import { Carousel, CarouselContent, CarouselNext, CarouselPrevious } from '../ui/carousel';
+
+const CustomCarousel = ({ contentStyle, length, children }: { contentStyle?: string; length: number; children: ReactNode }) => {
+  return (
+    <Carousel
+      opts={{
+        align: 'start',
+        dragFree: true,
+        watchDrag: false,
+      }}
+      className='w-full overflow-scroll'
+    >
+      <CarouselContent className={`flex items-center h-full ${contentStyle}`}>{children}</CarouselContent>
+      {length > 1 && (
+        <>
+          <CarouselPrevious className='z-50 ml-14' />
+          <CarouselNext className='z-50 mr-14' />
+        </>
+      )}
+    </Carousel>
+  );
+};
+
+export default CustomCarousel;

--- a/src/components/home/HomeAuctionItem.tsx
+++ b/src/components/home/HomeAuctionItem.tsx
@@ -6,6 +6,7 @@ import ParticipantCount from '../common/atomic/ParticipantCount';
 import TimeLabel from '../common/atomic/TimeLabel';
 import { truncateText } from '@/utils/truncateText';
 import { useNavigate } from 'react-router-dom';
+import { CarouselItem } from '../ui/carousel';
 
 type HomeAuctionItemProps<T> = T extends 'preAuction' ? { kind: 'preAuction'; auction: IPreAuctionItem } : { kind: 'auction'; auction: IAuctionItem };
 
@@ -16,21 +17,23 @@ const HomeAuctionItem = <T extends 'preAuction' | 'auction'>({ kind, auction }: 
   const name = truncateText(productName);
 
   return (
-    <figure className='flex flex-col w-[11rem] gap-2 border rounded text-body2 cursor-pointer' aria-label={kind} onClick={handleClick}>
-      <div className='relative'>
-        <img src={imageUrl} alt={`${kind}_이미지`} className='object-cover w-full h-[10rem] rounded-t' />
-        {kind === 'auction' && <TimeLabel time={auction.timeRemaining} />}
-      </div>
-      <figcaption className='flex flex-col gap-2 p-2'>
-        <div aria-label={`${kind}_이름`} className='text-gray1'>
-          {name}
+    <CarouselItem className='basis-1/2 md:basis-1/3'>
+      <figure className='flex flex-col gap-2 border rounded cursor-pointer text-body2' aria-label={kind} onClick={handleClick}>
+        <div className='relative'>
+          <img src={imageUrl} alt={`${kind}_이미지`} className='object-cover w-full h-[10rem] rounded-t' />
+          {kind === 'auction' && <TimeLabel time={auction.timeRemaining} />}
         </div>
-        <div>
-          <MinPrice price={minPrice} />
-          {kind === 'auction' ? <ParticipantCount count={auction.participantCount} /> : <LikeCount count={auction.likeCount} />}
-        </div>
-      </figcaption>
-    </figure>
+        <figcaption className='flex flex-col gap-2 p-2'>
+          <div aria-label={`${kind}_이름`} className='text-gray1'>
+            {name}
+          </div>
+          <div>
+            <MinPrice price={minPrice} />
+            {kind === 'auction' ? <ParticipantCount count={auction.participantCount} /> : <LikeCount count={auction.likeCount} />}
+          </div>
+        </figcaption>
+      </figure>
+    </CarouselItem>
   );
 };
 

--- a/src/components/home/HomeItemList.tsx
+++ b/src/components/home/HomeItemList.tsx
@@ -1,16 +1,10 @@
 import { ReactNode } from 'react';
 
-const HomeItemList = ({
-  children,
-  name,
-}: {
-  children: ReactNode;
-  name: string;
-}) => {
+const HomeItemList = ({ children, name }: { children: ReactNode; name: string }) => {
   return (
-    <section className="flex flex-col w-full gap-4">
-      <label className="text-lg font-semibold">{name}</label>
-      <div className="flex gap-4 overflow-x-scroll">{children}</div>
+    <section className='flex flex-col w-full gap-4'>
+      <label className='text-lg font-semibold'>{name}</label>
+      <div className='flex gap-4'>{children}</div>
     </section>
   );
 };

--- a/src/components/register/ImageUploader.tsx
+++ b/src/components/register/ImageUploader.tsx
@@ -4,6 +4,8 @@ import DeleteIcon from '@/assets/icons/delete.svg';
 import { Dispatch, SetStateAction } from 'react';
 import { Input } from '../ui/input';
 import AddImageButton from './AddImageButton';
+import { CarouselItem } from '../ui/carousel';
+import CustomCarousel from '../common/CustomCarousel';
 
 interface ImageUploaderProps {
   images: string[];
@@ -12,69 +14,54 @@ interface ImageUploaderProps {
   setFiles: Dispatch<SetStateAction<File[]>>;
 }
 
-const ImageUploader = ({
-  files,
-  setFiles,
-  images,
-  setImages,
-}: ImageUploaderProps) => {
-  const {
-    handleDragStart,
-    handleDragLeave,
-    handleDragOver,
-    handleDrop,
-    hoveredIndex,
-  } = useDragAndDrop(images, setImages);
-  const { fileInputRef, deleteImage, handleImage, handleBoxClick } =
-    useImageUploader(images, setImages, files, setFiles);
+const ImageUploader = ({ files, setFiles, images, setImages }: ImageUploaderProps) => {
+  const { handleDragStart, handleDragLeave, handleDragOver, handleDrop, hoveredIndex } = useDragAndDrop(images, setImages);
+  const { fileInputRef, deleteImage, handleImage, handleBoxClick } = useImageUploader(images, setImages, files, setFiles);
 
   return (
-    <div className="flex items-center gap-3 overflow-scroll min-h-36">
+    <div className='flex flex-col items-center w-full h-full gap-5 sm:flex-row'>
       <AddImageButton handleBoxClick={handleBoxClick} length={images.length} />
-      {images.map((image: string, index: number) => (
-        <div
-          className={`relative h-32 transition-transform duration-400 min-w-32 w-32 ${
-            index === hoveredIndex ? 'transform scale-105' : ''
-          }`}
-          draggable
-          key={image}
-          onDragStart={() => handleDragStart(index)}
-          onDragOver={(e) => {
-            e.preventDefault();
-            handleDragOver(e, index);
-          }}
-          onDragLeave={handleDragLeave}
-          onDrop={() => handleDrop(index)}
-        >
-          <img
-            src={image}
-            alt={`상품 사진 ${index}`}
-            className="object-cover w-full h-full border-2 rounded"
-          />
-          {index === 0 && (
-            <p className="absolute text-xs rounded py-1 px-2 text-white bg-[#454545]/90  top-[10%] left-[2.125rem]">
-              대표 사진
-            </p>
-          )}
-          <button
-            className="absolute top-[-5%] right-[-5%] cursor-pointer text-black size-6"
-            onClick={() => deleteImage(index)}
-            aria-label={`사진 삭제 ${index}`}
-          >
-            <img src={DeleteIcon} alt="사진 삭제 버튼" />
-          </button>
-        </div>
-      ))}
+      <CustomCarousel contentStyle='py-2' length={images.length}>
+        {images.map((image: string, index: number) => (
+          <CarouselItem className='basis-1/2 md:basis-1/3' key={image}>
+            <div
+              className={`relative h-32 mr-3 transition-transform duration-400 min-w-32  ${index === hoveredIndex ? 'transform scale-105' : ''}`}
+              draggable
+              onDragStart={() => handleDragStart(index)}
+              onDragOver={(e) => {
+                e.preventDefault();
+                handleDragOver(e, index);
+              }}
+              onDragLeave={handleDragLeave}
+              onDrop={() => handleDrop(index)}
+            >
+              <img src={image} alt={`상품 사진 ${index}`} className='object-cover w-full h-full border-2 rounded' />
+              {index === 0 && (
+                <p className='absolute text-[8px] sm:text-xs rounded py-1 px-2 text-white bg-[#454545]/90 top-2 left-1/2 transform -translate-x-1/2'>
+                  대표 사진
+                </p>
+              )}
+              <button
+                className='absolute top-[-5%] right-[-5%] cursor-pointer text-black size-6'
+                onClick={() => deleteImage(index)}
+                aria-label={`사진 삭제 ${index}`}
+              >
+                <img src={DeleteIcon} alt='사진 삭제 버튼' />
+              </button>
+            </div>
+          </CarouselItem>
+        ))}
+      </CustomCarousel>
       <Input
         ref={fileInputRef}
-        type="file"
-        id="사진"
-        className="hidden"
-        accept="image/*"
+        type='file'
+        id='사진'
+        className='hidden'
+        accept='image/*'
         multiple
         onChange={handleImage}
-        aria-label="사진 업로드 인풋"
-        role="button"
+        aria-label='사진 업로드 인풋'
+        role='button'
       />
     </div>
   );

--- a/src/components/register/RegisterCaution.tsx
+++ b/src/components/register/RegisterCaution.tsx
@@ -1,8 +1,4 @@
-import {
-  ENROLLMENT_CAUTION,
-  PRE_ENROLLMENT_CAUTION,
-} from '@/constants/caution';
-
+import { PRE_REGISTER_CAUTION, REGISTER_CAUTION } from '@/constants/caution';
 import CautionCheck from '../common/CautionCheck';
 
 interface CautionProps {
@@ -12,34 +8,29 @@ interface CautionProps {
 }
 
 const RegisterCaution = ({ kind, check, handleCheck }: CautionProps) => {
+  console.log(kind);
   return (
-    <section className="flex flex-col pt-5 gap-[3rem]">
-      <h3 className="text-heading2">
-        {kind === 'enroll'
-          ? ENROLLMENT_CAUTION.HEADING
-          : PRE_ENROLLMENT_CAUTION.HEADING}
-      </h3>
-      <div className="space-y-5">
-        {kind === 'enroll' ? (
+    <section className='flex flex-col pt-5 gap-[3rem]'>
+      <h3 className='text-heading2'>{kind === 'REGISTER' ? REGISTER_CAUTION.HEADING : PRE_REGISTER_CAUTION.HEADING}</h3>
+      <div className='space-y-5'>
+        {kind === 'REGISTER' ? (
           <>
-            <h4 className="text-body1Bold">{ENROLLMENT_CAUTION.TITLE}</h4>
-            {Object.entries(ENROLLMENT_CAUTION.CONTENT).map(([key, value]) => (
-              <div key={key} className="space-y-1 text-body2 text-gray2">
+            <h4 className='text-body1Bold'>{REGISTER_CAUTION.TITLE}</h4>
+            {Object.entries(REGISTER_CAUTION.CONTENT).map(([key, value]) => (
+              <div key={key} className='space-y-1 text-body2 text-gray2'>
                 <h5>{value.TITLE}</h5>
-                <p className="pl-3">{value.DESCRIPTION}</p>
+                <p className='pl-3'>{value.DESCRIPTION}</p>
               </div>
             ))}
           </>
         ) : (
-          <div className="space-y-5">
-            {Object.entries(PRE_ENROLLMENT_CAUTION.CONTENT).map(
-              ([key, value]) => (
-                <div className="space-y-4" key={key}>
-                  <h4 className="text-body1Bold">{value.TITLE}</h4>
-                  <p className="text-body2 text-gray2">{value.DESCRIPTION}</p>
-                </div>
-              ),
-            )}
+          <div className='space-y-5'>
+            {Object.entries(PRE_REGISTER_CAUTION.CONTENT).map(([key, value]) => (
+              <div className='space-y-4' key={key}>
+                <h4 className='text-body1Bold'>{value.TITLE}</h4>
+                <p className='text-body2 text-gray2'>{value.DESCRIPTION}</p>
+              </div>
+            ))}
           </div>
         )}
         <CautionCheck check={check} handleCheck={handleCheck} />

--- a/src/components/register/quries.ts
+++ b/src/components/register/quries.ts
@@ -3,6 +3,7 @@ import { UseMutateFunction, useMutation } from '@tanstack/react-query';
 import { API_END_POINT } from '@/constants/api';
 import { httpClient } from '@/api/axios';
 import { useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
 
 export const usePostRegister = (): {
   mutate: UseMutateFunction<unknown, Error, FormData, unknown>;
@@ -19,7 +20,9 @@ export const usePostRegister = (): {
 
   const { mutate } = useMutation({
     mutationFn: postRegister,
-    onSuccess: () => navigate('/'),
+    onSuccess: () => {
+      navigate('/'), toast.success('경매가 등록되었습니다.');
+    },
   });
 
   return { mutate };

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,56 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        outline:
+          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-10 px-4 py-2",
+        sm: "h-9 rounded-md px-3",
+        lg: "h-11 rounded-md px-8",
+        icon: "h-10 w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button"
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Button.displayName = "Button"
+
+export { Button, buttonVariants }

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -1,0 +1,260 @@
+import * as React from "react"
+import useEmblaCarousel, {
+  type UseEmblaCarouselType,
+} from "embla-carousel-react"
+import { ArrowLeft, ArrowRight } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+type CarouselApi = UseEmblaCarouselType[1]
+type UseCarouselParameters = Parameters<typeof useEmblaCarousel>
+type CarouselOptions = UseCarouselParameters[0]
+type CarouselPlugin = UseCarouselParameters[1]
+
+type CarouselProps = {
+  opts?: CarouselOptions
+  plugins?: CarouselPlugin
+  orientation?: "horizontal" | "vertical"
+  setApi?: (api: CarouselApi) => void
+}
+
+type CarouselContextProps = {
+  carouselRef: ReturnType<typeof useEmblaCarousel>[0]
+  api: ReturnType<typeof useEmblaCarousel>[1]
+  scrollPrev: () => void
+  scrollNext: () => void
+  canScrollPrev: boolean
+  canScrollNext: boolean
+} & CarouselProps
+
+const CarouselContext = React.createContext<CarouselContextProps | null>(null)
+
+function useCarousel() {
+  const context = React.useContext(CarouselContext)
+
+  if (!context) {
+    throw new Error("useCarousel must be used within a <Carousel />")
+  }
+
+  return context
+}
+
+const Carousel = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & CarouselProps
+>(
+  (
+    {
+      orientation = "horizontal",
+      opts,
+      setApi,
+      plugins,
+      className,
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    const [carouselRef, api] = useEmblaCarousel(
+      {
+        ...opts,
+        axis: orientation === "horizontal" ? "x" : "y",
+      },
+      plugins
+    )
+    const [canScrollPrev, setCanScrollPrev] = React.useState(false)
+    const [canScrollNext, setCanScrollNext] = React.useState(false)
+
+    const onSelect = React.useCallback((api: CarouselApi) => {
+      if (!api) {
+        return
+      }
+
+      setCanScrollPrev(api.canScrollPrev())
+      setCanScrollNext(api.canScrollNext())
+    }, [])
+
+    const scrollPrev = React.useCallback(() => {
+      api?.scrollPrev()
+    }, [api])
+
+    const scrollNext = React.useCallback(() => {
+      api?.scrollNext()
+    }, [api])
+
+    const handleKeyDown = React.useCallback(
+      (event: React.KeyboardEvent<HTMLDivElement>) => {
+        if (event.key === "ArrowLeft") {
+          event.preventDefault()
+          scrollPrev()
+        } else if (event.key === "ArrowRight") {
+          event.preventDefault()
+          scrollNext()
+        }
+      },
+      [scrollPrev, scrollNext]
+    )
+
+    React.useEffect(() => {
+      if (!api || !setApi) {
+        return
+      }
+
+      setApi(api)
+    }, [api, setApi])
+
+    React.useEffect(() => {
+      if (!api) {
+        return
+      }
+
+      onSelect(api)
+      api.on("reInit", onSelect)
+      api.on("select", onSelect)
+
+      return () => {
+        api?.off("select", onSelect)
+      }
+    }, [api, onSelect])
+
+    return (
+      <CarouselContext.Provider
+        value={{
+          carouselRef,
+          api: api,
+          opts,
+          orientation:
+            orientation || (opts?.axis === "y" ? "vertical" : "horizontal"),
+          scrollPrev,
+          scrollNext,
+          canScrollPrev,
+          canScrollNext,
+        }}
+      >
+        <div
+          ref={ref}
+          onKeyDownCapture={handleKeyDown}
+          className={cn("relative", className)}
+          role="region"
+          aria-roledescription="carousel"
+          {...props}
+        >
+          {children}
+        </div>
+      </CarouselContext.Provider>
+    )
+  }
+)
+Carousel.displayName = "Carousel"
+
+const CarouselContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+  const { carouselRef, orientation } = useCarousel()
+
+  return (
+    <div ref={carouselRef} className="overflow-hidden">
+      <div
+        ref={ref}
+        className={cn(
+          "flex",
+          orientation === "horizontal" ? "-ml-4" : "-mt-4 flex-col",
+          className
+        )}
+        {...props}
+      />
+    </div>
+  )
+})
+CarouselContent.displayName = "CarouselContent"
+
+const CarouselItem = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+  const { orientation } = useCarousel()
+
+  return (
+    <div
+      ref={ref}
+      role="group"
+      aria-roledescription="slide"
+      className={cn(
+        "min-w-0 shrink-0 grow-0 basis-full",
+        orientation === "horizontal" ? "pl-4" : "pt-4",
+        className
+      )}
+      {...props}
+    />
+  )
+})
+CarouselItem.displayName = "CarouselItem"
+
+const CarouselPrevious = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<typeof Button>
+>(({ className, variant = "outline", size = "icon", ...props }, ref) => {
+  const { orientation, scrollPrev, canScrollPrev } = useCarousel()
+
+  return (
+    <Button
+      ref={ref}
+      variant={variant}
+      size={size}
+      className={cn(
+        "absolute  h-8 w-8 rounded-full",
+        orientation === "horizontal"
+          ? "-left-12 top-1/2 -translate-y-1/2"
+          : "-top-12 left-1/2 -translate-x-1/2 rotate-90",
+        className
+      )}
+      disabled={!canScrollPrev}
+      onClick={scrollPrev}
+      {...props}
+    >
+      <ArrowLeft className="h-4 w-4" />
+      <span className="sr-only">Previous slide</span>
+    </Button>
+  )
+})
+CarouselPrevious.displayName = "CarouselPrevious"
+
+const CarouselNext = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<typeof Button>
+>(({ className, variant = "outline", size = "icon", ...props }, ref) => {
+  const { orientation, scrollNext, canScrollNext } = useCarousel()
+
+  return (
+    <Button
+      ref={ref}
+      variant={variant}
+      size={size}
+      className={cn(
+        "absolute h-8 w-8 rounded-full",
+        orientation === "horizontal"
+          ? "-right-12 top-1/2 -translate-y-1/2"
+          : "-bottom-12 left-1/2 -translate-x-1/2 rotate-90",
+        className
+      )}
+      disabled={!canScrollNext}
+      onClick={scrollNext}
+      {...props}
+    >
+      <ArrowRight className="h-4 w-4" />
+      <span className="sr-only">Next slide</span>
+    </Button>
+  )
+})
+CarouselNext.displayName = "CarouselNext"
+
+export {
+  type CarouselApi,
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselPrevious,
+  CarouselNext,
+}

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -1,122 +1,106 @@
-import * as React from "react"
-import useEmblaCarousel, {
-  type UseEmblaCarouselType,
-} from "embla-carousel-react"
-import { ArrowLeft, ArrowRight } from "lucide-react"
+import * as React from 'react';
+import useEmblaCarousel, { type UseEmblaCarouselType } from 'embla-carousel-react';
+import { ArrowLeft, ArrowRight } from 'lucide-react';
 
-import { cn } from "@/lib/utils"
-import { Button } from "@/components/ui/button"
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
 
-type CarouselApi = UseEmblaCarouselType[1]
-type UseCarouselParameters = Parameters<typeof useEmblaCarousel>
-type CarouselOptions = UseCarouselParameters[0]
-type CarouselPlugin = UseCarouselParameters[1]
+type CarouselApi = UseEmblaCarouselType[1];
+type UseCarouselParameters = Parameters<typeof useEmblaCarousel>;
+type CarouselOptions = UseCarouselParameters[0];
+type CarouselPlugin = UseCarouselParameters[1];
 
 type CarouselProps = {
-  opts?: CarouselOptions
-  plugins?: CarouselPlugin
-  orientation?: "horizontal" | "vertical"
-  setApi?: (api: CarouselApi) => void
-}
+  opts?: CarouselOptions;
+  plugins?: CarouselPlugin;
+  orientation?: 'horizontal' | 'vertical';
+  setApi?: (api: CarouselApi) => void;
+};
 
 type CarouselContextProps = {
-  carouselRef: ReturnType<typeof useEmblaCarousel>[0]
-  api: ReturnType<typeof useEmblaCarousel>[1]
-  scrollPrev: () => void
-  scrollNext: () => void
-  canScrollPrev: boolean
-  canScrollNext: boolean
-} & CarouselProps
+  carouselRef: ReturnType<typeof useEmblaCarousel>[0];
+  api: ReturnType<typeof useEmblaCarousel>[1];
+  scrollPrev: () => void;
+  scrollNext: () => void;
+  canScrollPrev: boolean;
+  canScrollNext: boolean;
+} & CarouselProps;
 
-const CarouselContext = React.createContext<CarouselContextProps | null>(null)
+const CarouselContext = React.createContext<CarouselContextProps | null>(null);
 
 function useCarousel() {
-  const context = React.useContext(CarouselContext)
+  const context = React.useContext(CarouselContext);
 
   if (!context) {
-    throw new Error("useCarousel must be used within a <Carousel />")
+    throw new Error('useCarousel must be used within a <Carousel />');
   }
 
-  return context
+  return context;
 }
 
-const Carousel = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement> & CarouselProps
->(
-  (
-    {
-      orientation = "horizontal",
-      opts,
-      setApi,
-      plugins,
-      className,
-      children,
-      ...props
-    },
-    ref
-  ) => {
+const Carousel = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement> & CarouselProps>(
+  ({ orientation = 'horizontal', opts, setApi, plugins, className, children, ...props }, ref) => {
     const [carouselRef, api] = useEmblaCarousel(
       {
         ...opts,
-        axis: orientation === "horizontal" ? "x" : "y",
+        axis: orientation === 'horizontal' ? 'x' : 'y',
       },
       plugins
-    )
-    const [canScrollPrev, setCanScrollPrev] = React.useState(false)
-    const [canScrollNext, setCanScrollNext] = React.useState(false)
+    );
+    const [canScrollPrev, setCanScrollPrev] = React.useState(false);
+    const [canScrollNext, setCanScrollNext] = React.useState(false);
 
     const onSelect = React.useCallback((api: CarouselApi) => {
       if (!api) {
-        return
+        return;
       }
 
-      setCanScrollPrev(api.canScrollPrev())
-      setCanScrollNext(api.canScrollNext())
-    }, [])
+      setCanScrollPrev(api.canScrollPrev());
+      setCanScrollNext(api.canScrollNext());
+    }, []);
 
     const scrollPrev = React.useCallback(() => {
-      api?.scrollPrev()
-    }, [api])
+      api?.scrollPrev();
+    }, [api]);
 
     const scrollNext = React.useCallback(() => {
-      api?.scrollNext()
-    }, [api])
+      api?.scrollNext();
+    }, [api]);
 
     const handleKeyDown = React.useCallback(
       (event: React.KeyboardEvent<HTMLDivElement>) => {
-        if (event.key === "ArrowLeft") {
-          event.preventDefault()
-          scrollPrev()
-        } else if (event.key === "ArrowRight") {
-          event.preventDefault()
-          scrollNext()
+        if (event.key === 'ArrowLeft') {
+          event.preventDefault();
+          scrollPrev();
+        } else if (event.key === 'ArrowRight') {
+          event.preventDefault();
+          scrollNext();
         }
       },
       [scrollPrev, scrollNext]
-    )
+    );
 
     React.useEffect(() => {
       if (!api || !setApi) {
-        return
+        return;
       }
 
-      setApi(api)
-    }, [api, setApi])
+      setApi(api);
+    }, [api, setApi]);
 
     React.useEffect(() => {
       if (!api) {
-        return
+        return;
       }
 
-      onSelect(api)
-      api.on("reInit", onSelect)
-      api.on("select", onSelect)
+      onSelect(api);
+      api.on('reInit', onSelect);
+      api.on('select', onSelect);
 
       return () => {
-        api?.off("select", onSelect)
-      }
-    }, [api, onSelect])
+        api?.off('select', onSelect);
+      };
+    }, [api, onSelect]);
 
     return (
       <CarouselContext.Provider
@@ -124,137 +108,98 @@ const Carousel = React.forwardRef<
           carouselRef,
           api: api,
           opts,
-          orientation:
-            orientation || (opts?.axis === "y" ? "vertical" : "horizontal"),
+          orientation: orientation || (opts?.axis === 'y' ? 'vertical' : 'horizontal'),
           scrollPrev,
           scrollNext,
           canScrollPrev,
           canScrollNext,
         }}
       >
-        <div
-          ref={ref}
-          onKeyDownCapture={handleKeyDown}
-          className={cn("relative", className)}
-          role="region"
-          aria-roledescription="carousel"
-          {...props}
-        >
+        <div ref={ref} onKeyDownCapture={handleKeyDown} className={cn('relative', className)} role='region' aria-roledescription='carousel' {...props}>
           {children}
         </div>
       </CarouselContext.Provider>
-    )
+    );
   }
-)
-Carousel.displayName = "Carousel"
+);
+Carousel.displayName = 'Carousel';
 
-const CarouselContent = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => {
-  const { carouselRef, orientation } = useCarousel()
+const CarouselContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => {
+  const { carouselRef, orientation } = useCarousel();
 
   return (
-    <div ref={carouselRef} className="overflow-hidden">
-      <div
-        ref={ref}
-        className={cn(
-          "flex",
-          orientation === "horizontal" ? "-ml-4" : "-mt-4 flex-col",
-          className
-        )}
-        {...props}
-      />
+    <div ref={carouselRef} className='overflow-hidden'>
+      <div ref={ref} className={cn('flex', orientation === 'horizontal' ? '-ml-4' : '-mt-4 flex-col', className)} {...props} />
     </div>
-  )
-})
-CarouselContent.displayName = "CarouselContent"
+  );
+});
+CarouselContent.displayName = 'CarouselContent';
 
-const CarouselItem = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => {
-  const { orientation } = useCarousel()
+const CarouselItem = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => {
+  const { orientation } = useCarousel();
 
   return (
     <div
       ref={ref}
-      role="group"
-      aria-roledescription="slide"
-      className={cn(
-        "min-w-0 shrink-0 grow-0 basis-full",
-        orientation === "horizontal" ? "pl-4" : "pt-4",
-        className
-      )}
+      role='group'
+      aria-roledescription='slide'
+      className={cn('min-w-0 shrink-0 grow-0 basis-full', orientation === 'horizontal' ? 'pl-4' : 'pt-4', className)}
       {...props}
     />
-  )
-})
-CarouselItem.displayName = "CarouselItem"
+  );
+});
+CarouselItem.displayName = 'CarouselItem';
 
-const CarouselPrevious = React.forwardRef<
-  HTMLButtonElement,
-  React.ComponentProps<typeof Button>
->(({ className, variant = "outline", size = "icon", ...props }, ref) => {
-  const { orientation, scrollPrev, canScrollPrev } = useCarousel()
+const CarouselPrevious = React.forwardRef<HTMLButtonElement, React.ComponentProps<typeof Button>>(
+  ({ className, variant = 'outline', size = 'icon', ...props }, ref) => {
+    const { orientation, scrollPrev, canScrollPrev } = useCarousel();
 
-  return (
-    <Button
-      ref={ref}
-      variant={variant}
-      size={size}
-      className={cn(
-        "absolute  h-8 w-8 rounded-full",
-        orientation === "horizontal"
-          ? "-left-12 top-1/2 -translate-y-1/2"
-          : "-top-12 left-1/2 -translate-x-1/2 rotate-90",
-        className
-      )}
-      disabled={!canScrollPrev}
-      onClick={scrollPrev}
-      {...props}
-    >
-      <ArrowLeft className="h-4 w-4" />
-      <span className="sr-only">Previous slide</span>
-    </Button>
-  )
-})
-CarouselPrevious.displayName = "CarouselPrevious"
+    return (
+      <Button
+        ref={ref}
+        variant={variant}
+        size={size}
+        className={cn(
+          'absolute  h-8 w-8 rounded-full',
+          orientation === 'horizontal' ? '-left-12 top-1/2 -translate-y-1/2' : '-top-12 left-1/2 -translate-x-1/2 rotate-90',
+          className
+        )}
+        disabled={!canScrollPrev}
+        onClick={scrollPrev}
+        {...props}
+      >
+        <ArrowLeft className='w-4 h-4' />
+        <span className='sr-only'>Previous slide</span>
+      </Button>
+    );
+  }
+);
+CarouselPrevious.displayName = 'CarouselPrevious';
 
-const CarouselNext = React.forwardRef<
-  HTMLButtonElement,
-  React.ComponentProps<typeof Button>
->(({ className, variant = "outline", size = "icon", ...props }, ref) => {
-  const { orientation, scrollNext, canScrollNext } = useCarousel()
+const CarouselNext = React.forwardRef<HTMLButtonElement, React.ComponentProps<typeof Button>>(
+  ({ className, variant = 'outline', size = 'icon', ...props }, ref) => {
+    const { orientation, scrollNext, canScrollNext } = useCarousel();
 
-  return (
-    <Button
-      ref={ref}
-      variant={variant}
-      size={size}
-      className={cn(
-        "absolute h-8 w-8 rounded-full",
-        orientation === "horizontal"
-          ? "-right-12 top-1/2 -translate-y-1/2"
-          : "-bottom-12 left-1/2 -translate-x-1/2 rotate-90",
-        className
-      )}
-      disabled={!canScrollNext}
-      onClick={scrollNext}
-      {...props}
-    >
-      <ArrowRight className="h-4 w-4" />
-      <span className="sr-only">Next slide</span>
-    </Button>
-  )
-})
-CarouselNext.displayName = "CarouselNext"
+    return (
+      <Button
+        ref={ref}
+        variant={variant}
+        size={size}
+        className={cn(
+          'absolute h-8 w-8 rounded-full',
+          orientation === 'horizontal' ? '-right-12 top-1/2 -translate-y-1/2' : '-bottom-12 left-1/2 -translate-x-1/2 rotate-90',
+          className
+        )}
+        disabled={!canScrollNext}
+        onClick={scrollNext}
+        {...props}
+      >
+        <ArrowRight className='w-4 h-4' />
+        <span className='sr-only'>Next slide</span>
+      </Button>
+    );
+  }
+);
+CarouselNext.displayName = 'CarouselNext';
 
-export {
-  type CarouselApi,
-  Carousel,
-  CarouselContent,
-  CarouselItem,
-  CarouselPrevious,
-  CarouselNext,
-}
+export { type CarouselApi, Carousel, CarouselContent, CarouselItem, CarouselPrevious, CarouselNext };

--- a/src/constants/caution.ts
+++ b/src/constants/caution.ts
@@ -1,4 +1,4 @@
-export const PRE_ENROLLMENT_CAUTION = Object.freeze({
+export const PRE_REGISTER_CAUTION = Object.freeze({
   HEADING: '사전 등록을 완료하시겠습니까?',
   CONTENT: {
     INFO: {
@@ -14,14 +14,13 @@ export const PRE_ENROLLMENT_CAUTION = Object.freeze({
   },
 });
 
-export const ENROLLMENT_CAUTION = Object.freeze({
+export const REGISTER_CAUTION = Object.freeze({
   HEADING: '경매 등록을 완료하시겠습니까?',
   TITLE: '경매 등록 주의사항',
   CONTENT: {
     PRODUCT_INFO: {
       TITLE: '1. 상품 정보 정확히 기재하기',
-      DESCRIPTION:
-        '판매자는 상품의 상태, 기능, 크기 등을 포함한 모든 정보를 정확하고 상세하게 기재해야 합니다.',
+      DESCRIPTION: '판매자는 상품의 상태, 기능, 크기 등을 포함한 모든 정보를 정확하고 상세하게 기재해야 합니다.',
     },
     DEFECTS_DISCLOSURE: {
       TITLE: '2. 제품 결함 및 상태 명시',
@@ -35,8 +34,7 @@ export const ENROLLMENT_CAUTION = Object.freeze({
     },
     BIDDING_RESTRICTIONS: {
       TITLE: '4. 경매 제한 시간 및 최고 입찰가 공개',
-      DESCRIPTION:
-        '최고 입찰가는 낙찰이 확정된 후 공개되므로, 판매자는 이 점을 유의하여 경매를 진행해야 합니다.',
+      DESCRIPTION: '최고 입찰가는 낙찰이 확정된 후 공개되므로, 판매자는 이 점을 유의하여 경매를 진행해야 합니다.',
     },
   },
 });
@@ -47,32 +45,27 @@ export const BID_CAUTION = Object.freeze({
     {
       ID: 1,
       TITLE: '1. 입찰 전 상품 확인',
-      DESCRIPTION:
-        '경매에 참여하기 전에 반드시 상품의 상세 정보와 상태를 확인하세요.',
+      DESCRIPTION: '경매에 참여하기 전에 반드시 상품의 상세 정보와 상태를 확인하세요.',
     },
     {
       ID: 2,
       TITLE: '2. 수정 제한 및 규칙 준수',
-      DESCRIPTION:
-        '입찰 후 가격 수정은 2번만 가능합니다. 신중하게 입찰 금액을 설정하고, 입찰 전 다시 한 번 확인하세요.',
+      DESCRIPTION: '입찰 후 가격 수정은 2번만 가능합니다. 신중하게 입찰 금액을 설정하고, 입찰 전 다시 한 번 확인하세요.',
     },
     {
       ID: 3,
       TITLE: '3. 결제 기한 준수',
-      DESCRIPTION:
-        '낙찰 후 24시간 이내에 결제를 완료해야 합니다. 기한 내 결제가 이루어지지 않으면 낙찰이 취소될 수 있습니다.',
+      DESCRIPTION: '낙찰 후 24시간 이내에 결제를 완료해야 합니다. 기한 내 결제가 이루어지지 않으면 낙찰이 취소될 수 있습니다.',
     },
     {
       ID: 4,
       TITLE: '4. 환불 및 교환 불가',
-      DESCRIPTION:
-        '경매 특성상 낙찰된 상품은 환불 및 교환이 불가합니다. 상품 상세 정보를 충분히 확인한 후 입찰해 주세요.',
+      DESCRIPTION: '경매 특성상 낙찰된 상품은 환불 및 교환이 불가합니다. 상품 상세 정보를 충분히 확인한 후 입찰해 주세요.',
     },
     {
       ID: 5,
       TITLE: '5. 부정행위 금지',
-      DESCRIPTION:
-        '부정한 방법으로 경매에 참여할 경우 계정이 영구 정지될 수 있습니다. 공정한 경매 문화를 유지하기 위해 협조해 주세요.',
+      DESCRIPTION: '부정한 방법으로 경매에 참여할 경우 계정이 영구 정지될 수 있습니다. 공정한 경매 문화를 유지하기 위해 협조해 주세요.',
     },
   ],
 });
@@ -83,26 +76,22 @@ export const EDIT_BID_CAUTION = Object.freeze({
     {
       ID: 1,
       TITLE: '1. 수정 제한 및 규칙 준수',
-      DESCRIPTION:
-        '경매 진행 중 입찰 금액을 2회 이상 수정할 수 없습니다. 모든 수정은 신중히 결정해 주세요.',
+      DESCRIPTION: '경매 진행 중 입찰 금액을 2회 이상 수정할 수 없습니다. 모든 수정은 신중히 결정해 주세요.',
     },
     {
       ID: 2,
       TITLE: '2. 결제 기한 준수',
-      DESCRIPTION:
-        '낙찰 후 24시간 이내에 결제를 완료해야 합니다. 기한 내 결제가 이루어지지 않으면 낙찰이 취소될 수 있습니다.',
+      DESCRIPTION: '낙찰 후 24시간 이내에 결제를 완료해야 합니다. 기한 내 결제가 이루어지지 않으면 낙찰이 취소될 수 있습니다.',
     },
     {
       ID: 3,
       TITLE: '3. 환불 및 교환 불가',
-      DESCRIPTION:
-        '경매 특성상 낙찰된 상품은 환불 및 교환이 불가합니다. 상품 상세 정보를 충분히 확인한 후 입찰해 주세요.',
+      DESCRIPTION: '경매 특성상 낙찰된 상품은 환불 및 교환이 불가합니다. 상품 상세 정보를 충분히 확인한 후 입찰해 주세요.',
     },
     {
       ID: 4,
       TITLE: '4. 부정행위 금지',
-      DESCRIPTION:
-        '부정한 방법으로 경매에 참여할 경우 계정이 영구 정지될 수 있습니다. 공정한 경매 문화를 유지하기 위해 협조해 주세요.',
+      DESCRIPTION: '부정한 방법으로 경매에 참여할 경우 계정이 영구 정지될 수 있습니다. 공정한 경매 문화를 유지하기 위해 협조해 주세요.',
     },
   ],
 });

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -7,6 +7,7 @@ import HomeItemList from '@/components/home/HomeItemList';
 import HomeRegisterBtn from '@/components/home/HomeRegisterBtn';
 import { useGetHomeAuctions } from '@/components/home/queries';
 import { useScrollDetection } from '@/hooks/useScrollDetection';
+import CustomCarousel from '@/components/common/CustomCarousel';
 
 const Home = () => {
   const { isScrolled, elementRef } = useScrollDetection(0);
@@ -17,16 +18,20 @@ const Home = () => {
       <div className='flex flex-col gap-10'>
         <HomeItemList name='베스트 경매'>
           <EmptyBoundary dataLength={bestAuctions.length} type='best'>
-            {bestAuctions.map((auction: IAuctionItem) => (
-              <HomeAuctionItem key={auction.auctionId} kind='auction' auction={auction} />
-            ))}
+            <CustomCarousel length={bestAuctions.length}>
+              {bestAuctions.map((auction: IAuctionItem) => (
+                <HomeAuctionItem key={auction.auctionId} kind='auction' auction={auction} />
+              ))}
+            </CustomCarousel>
           </EmptyBoundary>
         </HomeItemList>
         <HomeItemList name='종료 임박 경매'>
           <EmptyBoundary dataLength={imminentAuctions.length} type='imminent'>
-            {imminentAuctions.map((auction: IAuctionItem) => (
-              <HomeAuctionItem key={auction.auctionId} kind='auction' auction={auction} />
-            ))}
+            <CustomCarousel length={imminentAuctions.length}>
+              {imminentAuctions.map((auction: IAuctionItem) => (
+                <HomeAuctionItem key={auction.auctionId} kind='auction' auction={auction} />
+              ))}
+            </CustomCarousel>
           </EmptyBoundary>
         </HomeItemList>
         <HomeItemList name='카테고리'>
@@ -34,9 +39,11 @@ const Home = () => {
         </HomeItemList>
         <HomeItemList name='사전 등록 경매'>
           <EmptyBoundary dataLength={preAuctions.length} type='preAuction'>
-            {preAuctions.map((auction: IPreAuctionItem) => (
-              <HomeAuctionItem key={auction.productId} kind='preAuction' auction={auction} />
-            ))}
+            <CustomCarousel length={preAuctions.length}>
+              {preAuctions.map((auction: IPreAuctionItem) => (
+                <HomeAuctionItem key={auction.productId} kind='preAuction' auction={auction} />
+              ))}
+            </CustomCarousel>
           </EmptyBoundary>
         </HomeItemList>
       </div>


### PR DESCRIPTION
## 💡 작업 내용

홈페이지, 경매 등록 페이지에서 여러 이미지를 잘 보기 위해 캐러셀을 적용한다.

- [x] shadcn carousel add.
- [x] CustomCarousel 컴포넌트 작성
- [x] 홈페이지 이미지에 적용.
- [x] 경매 등록 이미지에 적용. 

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #96 
