### PR TITLE
Feat: 사전경매 페이지 footer 구현

### DIFF
--- a/src/components/details/BuyersFooter.tsx
+++ b/src/components/details/BuyersFooter.tsx
@@ -47,7 +47,7 @@ const BuyersFooter: React.FC<BuyersFooterProps> = ({
   }
 
   // 3. 판매자가 아니면서 경매 아이템이 PROCEEDING이고, 경매에 참여했으면서 가격 수정 횟수가 남아있을 때
-  if (status === 'PROCEEDING' && isParticipated && remainingBidCount > 0) {
+  if (status === 'PROCEEDING' && isParticipated && remainingBidCount && remainingBidCount > 0) {
     return (
       <div className='flex items-center justify-between p-2 rounded-lg'>
         <button className='px-4 py-2 text-gray-600 border border-gray-400 rounded-lg'>

--- a/src/components/details/BuyersFooter.tsx
+++ b/src/components/details/BuyersFooter.tsx
@@ -5,11 +5,17 @@ interface BuyersFooterProps {
   auctionId: number;
   isSeller: boolean;
   status: string;
-  isParticipating: boolean;
-  remainingBidCount: number;
+  isParticipated: boolean;
+  remainingBidCount?: number;
 }
 
-const BuyersFooter: React.FC<BuyersFooterProps> = ({ auctionId, isSeller, status, isParticipating, remainingBidCount }) => {
+const BuyersFooter: React.FC<BuyersFooterProps> = ({
+  auctionId,
+  isSeller,
+  status,
+  isParticipated,
+  remainingBidCount,
+}) => {
   const navigate = useNavigate();
 
   const onMoveToBidHandler = () => {
@@ -21,41 +27,58 @@ const BuyersFooter: React.FC<BuyersFooterProps> = ({ auctionId, isSeller, status
 
   // 1. 판매자가 아니면서 경매 아이템이 PENDING일 경우
   if (status === 'PENDING') {
-    return <div className='p-2 text-center bg-gray-200 rounded-lg'>오픈 알림 받기</div>;
+    return (
+      <div className='p-2 text-center bg-gray-200 rounded-lg'>
+        오픈 알림 받기
+      </div>
+    );
   }
 
   // 2. 판매자가 아니면서 경매 아이템이 PROCEEDING이고, 아직 참여하지 않았을 경우
-  if (status === 'PROCEEDING' && !isParticipating) {
+  if (status === 'PROCEEDING' && !isParticipated) {
     return (
-      <button className='w-full px-4 py-2 text-white transition-colors bg-orange-500 rounded-lg hover:bg-orange-600' onClick={onMoveToBidHandler}>
+      <button
+        className='w-full px-4 py-2 text-white transition-colors bg-orange-500 rounded-lg hover:bg-orange-600'
+        onClick={onMoveToBidHandler}
+      >
         경매 참여하기
       </button>
     );
   }
 
   // 3. 판매자가 아니면서 경매 아이템이 PROCEEDING이고, 경매에 참여했으면서 가격 수정 횟수가 남아있을 때
-  if (status === 'PROCEEDING' && isParticipating && remainingBidCount > 0) {
+  if (status === 'PROCEEDING' && isParticipated && remainingBidCount > 0) {
     return (
       <div className='flex items-center justify-between p-2 rounded-lg'>
-        <button className='px-4 py-2 text-gray-600 border border-gray-400 rounded-lg'>참여 취소</button>
-        <button className='px-4 py-2 text-white transition-colors bg-orange-500 rounded-lg hover:bg-orange-600'>금액 수정({remainingBidCount}회 가능)</button>
+        <button className='px-4 py-2 text-gray-600 border border-gray-400 rounded-lg'>
+          참여 취소
+        </button>
+        <button className='px-4 py-2 text-white transition-colors bg-orange-500 rounded-lg hover:bg-orange-600'>
+          금액 수정({remainingBidCount}회 가능)
+        </button>
       </div>
     );
   }
 
   // 4. 판매자가 아니면서 경매 아이템이 PROCEEDING이고, 경매에 참여했으면서 가격 수정 횟수가 모두 소진됐을 때
-  if (status === 'PROCEEDING' && isParticipating && remainingBidCount === 0) {
+  if (status === 'PROCEEDING' && isParticipated && remainingBidCount === 0) {
     return (
       <div className='flex items-center justify-between p-2 rounded-lg'>
-        <button className='px-4 py-2 text-gray-600 border border-gray-400 rounded-lg'>참여 취소</button>
-        <button className='px-4 py-2 text-white bg-gray-400 rounded-lg cursor-not-allowed'>금액 수정(소진)</button>
+        <button className='px-4 py-2 text-gray-600 border border-gray-400 rounded-lg'>
+          참여 취소
+        </button>
+        <button className='px-4 py-2 text-white bg-gray-400 rounded-lg cursor-not-allowed'>
+          금액 수정(소진)
+        </button>
       </div>
     );
   }
 
   // 5. 경매가 종료되었을 때
-  if (status === 'COMPLETED') {
-    return <div className='p-2 text-center bg-gray-300 rounded-lg'>종료된 경매</div>;
+  if (status === 'ENDED') {
+    return (
+      <div className='p-2 text-center bg-gray-300 rounded-lg'>종료된 경매</div>
+    );
   }
 
   return null;

--- a/src/components/details/SellersFooter.tsx
+++ b/src/components/details/SellersFooter.tsx
@@ -4,7 +4,7 @@ import { AiOutlineHeart } from 'react-icons/ai';
 
 interface SellersFooterProps {
   isSeller: boolean;
-  status: string;
+  status?: string;
 }
 
 const SellersFooter: React.FC<SellersFooterProps> = ({ isSeller, status }) => {

--- a/src/pages/AuctionDetails.tsx
+++ b/src/pages/AuctionDetails.tsx
@@ -53,11 +53,18 @@ const AuctionDetails = () => {
           {/* 상품 이미지 영역 */}
           <div className='relative w-full bg-yellow-300'>
             <div className='w-full mb-2'>
-              <img src={`${auctionDetails.imageUrls[0]}`} alt={auctionDetails.productName} className='object-cover w-full h-auto' />
+              <img
+                src={`${auctionDetails.imageUrls[0]}`}
+                alt={auctionDetails.productName}
+                className='object-cover w-full h-auto'
+              />
             </div>
             {/* 타이머 및 프로그레스 바 */}
             {auctionDetails && (
-              <div id='timer-section' className={`bg-white z-10 py-1 ${isTimerFixed ? 'fixed top-0 left-0 right-0' : ''}`}>
+              <div
+                id='timer-section'
+                className={`bg-white z-10 py-1 ${isTimerFixed ? 'fixed top-0 left-0 right-0' : ''}`}
+              >
                 <ProgressBar
                   initialTimeRemaining={auctionDetails.timeRemaining}
                   totalTime={totalTime} // Should be 86400
@@ -71,14 +78,19 @@ const AuctionDetails = () => {
             {/* 경매 아이템 제목 & 시작가 */}
             {auctionDetails && (
               <div className='mb-4'>
-                <p className='mb-1 text-lg font-bold'>{auctionDetails.productName || '[ERROR] 이름이 등록되지 않았어요!'}</p>
+                <p className='mb-1 text-lg font-bold'>
+                  {auctionDetails.productName ||
+                    '[ERROR] 이름이 등록되지 않았어요!'}
+                </p>
                 <p className='text-sm text-gray-500'>
                   <span className='inline-flex items-center'>
                     <span className='mr-1'>
                       <img src={Price} alt='Price' />
                     </span>
                     시작가
-                    <span className='font-bold p'>{numberWithCommas(Number(auctionDetails.minPrice))}원</span>
+                    <span className='font-bold p'>
+                      {numberWithCommas(Number(auctionDetails.minPrice))}원
+                    </span>
                   </span>
                 </p>
               </div>
@@ -92,16 +104,26 @@ const AuctionDetails = () => {
                     <span className='ml-1'>나의 참여 금액</span>
                   </div>
                   <p className='text-xl font-bold text-gray-800'>
-                    {auctionDetails.isParticipated ? `${numberWithCommas(Number(auctionDetails.bidAmount))}원` : '참여 전'}
+                    {auctionDetails.isParticipated
+                      ? `${numberWithCommas(Number(auctionDetails.bidAmount))}원`
+                      : '참여 전'}
                   </p>
                 </div>
                 <div className='h-full border-l border-gray-300' />
                 <div className='flex flex-col items-center flex-1 py-4 text-center'>
                   <div className='flex items-center mb-1 text-sm text-gray-400'>
-                    <img src={Participants} alt='Participants' className='w-4 h-4 mx-2 mb-1' />
+                    <img
+                      src={Participants}
+                      alt='Participants'
+                      className='w-4 h-4 mx-2 mb-1'
+                    />
                     <p className='mb-1 text-sm text-gray-500'>참여 인원</p>
                   </div>
-                  <p className='text-lg font-bold'>{auctionDetails.participantCount ? `${auctionDetails.participantCount}명` : '0명'}</p>
+                  <p className='text-lg font-bold'>
+                    {auctionDetails.participantCount
+                      ? `${auctionDetails.participantCount}명`
+                      : '0명'}
+                  </p>
                 </div>
               </div>
             </div>
@@ -115,13 +137,16 @@ const AuctionDetails = () => {
         {/* 화면 하단에 고정된 Footer */}
         <Layout.Footer type={isPreAuction ? 'double' : 'single'}>
           {auctionDetails && auctionDetails.isSeller ? (
-            <SellersFooter isSeller={auctionDetails.isSeller} status={auctionDetails.status} />
+            <SellersFooter
+              isSeller={auctionDetails.isSeller}
+              status={auctionDetails.status}
+            />
           ) : (
             <BuyersFooter
               auctionId={auctionId}
               isSeller={auctionDetails.isSeller ?? false}
               status={auctionDetails.status ?? ''}
-              isParticipating={auctionDetails.isParticipated ?? false}
+              isParticipated={auctionDetails.isParticipated ?? false}
               remainingBidCount={auctionDetails.remainingBidCount ?? 0}
             />
           )}
@@ -129,11 +154,19 @@ const AuctionDetails = () => {
         {/* 백드롭 */}
         {isMenuOpen && (
           <>
-            <div className='absolute inset-0 z-40 bg-black bg-opacity-50' onClick={closeMenu} style={{ top: 0, bottom: 0 }} />
+            <div
+              className='absolute inset-0 z-40 bg-black bg-opacity-50'
+              onClick={closeMenu}
+              style={{ top: 0, bottom: 0 }}
+            />
             {/* 메뉴 (아코디언) */}
             <div className='absolute top-[10px] right-2 bg-white shadow-lg rounded-md z-50'>
-              <button className='flex items-center w-full px-4 py-2 text-left text-gray-700 hover:bg-gray-200'>수정하기</button>
-              <button className='flex items-center w-full px-4 py-2 text-left text-red-600 hover:bg-red-100'>삭제하기</button>
+              <button className='flex items-center w-full px-4 py-2 text-left text-gray-700 hover:bg-gray-200'>
+                수정하기
+              </button>
+              <button className='flex items-center w-full px-4 py-2 text-left text-red-600 hover:bg-red-100'>
+                삭제하기
+              </button>
             </div>
           </>
         )}

--- a/src/pages/PreAuctionDetails.tsx
+++ b/src/pages/PreAuctionDetails.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable prettier/prettier */
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 import Layout from '@/components/layout/Layout';
 import { useNavigate, LoaderFunction, useLoaderData } from 'react-router-dom';
@@ -30,7 +30,6 @@ const PreAuction = () => {
   const preAuctionId = useLoaderData() as number;
   const { preAuctionDetails } = useGetPreAuctionDetails(preAuctionId);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const [isLoading, setIsLoading] = useState(true);
   const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
   const [isDeleteSuccessOpen, setIsDeleteSuccessOpen] = useState(false);
 

--- a/src/pages/PreAuctionDetails.tsx
+++ b/src/pages/PreAuctionDetails.tsx
@@ -1,24 +1,42 @@
 /* eslint-disable prettier/prettier */
-import { useState } from 'react';
-import Layout from '@/components/layout/Layout';
-import axios from 'axios';
-import { LoaderFunction, useLoaderData, useNavigate } from 'react-router-dom';
-import Price from '@/assets/icons/price.svg';
+import { useEffect, useState } from 'react';
 
-// 삭제 확인 및 성공 메시지 모달 컴포넌트 임포트 (필요 시 직접 구현)
+import Layout from '@/components/layout/Layout';
+import { useNavigate, LoaderFunction, useLoaderData } from 'react-router-dom';
+import Price from '@/assets/icons/price.svg';
+import axios from 'axios';
+
+// 필요한 컴포넌트 임포트
+import SellersFooter from '@/components/details/SellersFooter';
+import BuyersFooter from '@/components/details/BuyersFooter';
 import ConfirmationModal from '@/components/details/ConfirmationModal';
 import SuccessModal from '@/components/details/SuccessModal';
 import { useGetPreAuctionDetails } from '@/components/details/queries';
 
-const PreAuctionDetails = () => {
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
+// interface PreAuctionDetails {
+//   productId: number;
+//   productName: string;
+//   sellerNickname: string;
+//   minPrice: number;
+//   createdAt: string;
+//   description: string;
+//   likeCount: number;
+//   isLiked: boolean;
+//   isSeller: boolean;
+//   imageUrls: string[];
+// }
+
+const PreAuction = () => {
   const preAuctionId = useLoaderData() as number;
   const { preAuctionDetails } = useGetPreAuctionDetails(preAuctionId);
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
   const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
   const [isDeleteSuccessOpen, setIsDeleteSuccessOpen] = useState(false);
 
-  const navigate = useNavigate();
+  console.log(preAuctionDetails);
 
+  const navigate = useNavigate();
   const handleBackClick = () => {
     navigate('/');
   };
@@ -31,48 +49,63 @@ const PreAuctionDetails = () => {
     setIsMenuOpen(false);
   };
 
+  const onEditButtonClickHandler = () => {
+    navigate(`/auctions/edit/${preAuctionId}`);
+  };
+
+  // 세자리 단위로 콤마를 찍어주는 함수
   const numberWithCommas = (x: number) => {
     return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
   };
 
+  // 삭제 버튼 클릭 핸들러
   const onDeleteButtonClickHandler = () => {
     setIsDeleteConfirmOpen(true);
     closeMenu();
   };
 
-  const onModifyButtonClickHandler = () => {
-    navigate(`/auctions/edit/${preAuctionDetails.productId}`);
-  };
-
-  const onConfirmDeleteHandler = async () => {
+  // 삭제 확인 다이얼로그에서 '삭제' 버튼 클릭 핸들러
+  const handleConfirmDelete = async () => {
     try {
-      await axios.delete(`${import.meta.env.VITE_API_URL}/api/v1/products/${preAuctionDetails.productId}`, {
-        headers: {
-          Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
-        },
-      });
+      await axios.delete(
+        `${import.meta.env.VITE_API_URL}/api/v1/products/${preAuctionId}`,
+        {
+          headers: {
+            Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
+          },
+        }
+      );
       setIsDeleteConfirmOpen(false);
       setIsDeleteSuccessOpen(true);
     } catch (error) {
-      setIsDeleteSuccessOpen(true);
+      alert('삭제하는 중 오류가 발생했습니다.');
     }
   };
 
-  const onCloseSuccessModalHandler = () => {
+  // 삭제 성공 메시지에서 '닫기' 버튼 클릭 핸들러
+  const handleCloseSuccessModal = () => {
     setIsDeleteSuccessOpen(false);
     navigate('/');
   };
 
   return (
     <Layout>
-      <Layout.Header title='제품 상세' handleBack={handleBackClick} handleModal={toggleMenu} />
+      <Layout.Header
+        title='제품 상세'
+        handleBack={handleBackClick}
+        handleModal={toggleMenu}
+      />
       {/* 메인 컨텐츠가 스크롤 가능하도록 수정 */}
       <div className='relative flex flex-col h-screen overflow-hidden'>
         <Layout.Main>
           {/* 상품 이미지 영역 */}
           <div className='relative w-full bg-yellow-300'>
             <div className='w-full mb-2'>
-              <img src={preAuctionDetails.imageUrls[0]} alt={preAuctionDetails.productName} className='object-cover w-full h-auto' />
+              <img
+                src={preAuctionDetails?.imageUrls[0]}
+                alt={preAuctionDetails?.productName}
+                className='object-cover w-full h-auto'
+              />
             </div>
           </div>
 
@@ -81,14 +114,19 @@ const PreAuctionDetails = () => {
             {/* 경매 아이템 제목 & 시작가 */}
             {preAuctionDetails && (
               <div className='mb-4'>
-                <p className='mb-1 text-lg font-bold'>{preAuctionDetails.productName || '[ERROR] 이름이 등록되지 않았어요!'}</p>
+                <p className='mb-1 text-lg font-bold'>
+                  {preAuctionDetails.productName ||
+                    '[ERROR] 이름이 등록되지 않았어요!'}
+                </p>
                 <p className='text-sm text-gray-500'>
                   <span className='inline-flex items-center'>
                     <span className='mr-1'>
                       <img src={Price} alt='Price' />
                     </span>
                     시작가
-                    <span className='font-bold p'>{numberWithCommas(Number(preAuctionDetails.minPrice))}원</span>
+                    <span className='font-bold p'>
+                      {numberWithCommas(preAuctionDetails.minPrice)}원
+                    </span>
                   </span>
                 </p>
               </div>
@@ -97,23 +135,44 @@ const PreAuctionDetails = () => {
 
           {/* 상품 설명 */}
           <div className='px-4 mb-4 overflow-y-auto text-sm text-gray-700'>
-            <p>{preAuctionDetails.description}</p>
+            <p>{preAuctionDetails?.description}</p>
           </div>
         </Layout.Main>
         {/* 화면 하단에 고정된 Footer */}
         <Layout.Footer type='double'>
-          <div>TEMP</div>
+          {preAuctionDetails && preAuctionDetails.isSeller ? (
+            <SellersFooter
+              isSeller={preAuctionDetails.isSeller}
+              status='PENDING'
+            />
+          ) : (
+            <BuyersFooter
+              isSeller={preAuctionDetails?.isSeller}
+              auctionId={preAuctionId}
+              status='PENDING'
+              isParticipated={preAuctionDetails?.isLiked}
+            />
+          )}
         </Layout.Footer>
         {/* 백드롭 */}
         {isMenuOpen && (
           <>
-            <div className='absolute inset-0 z-40 bg-black bg-opacity-50' onClick={closeMenu} />
+            <div
+              className='absolute inset-0 z-40 bg-black bg-opacity-50'
+              onClick={closeMenu}
+            />
             {/* 메뉴 (아코디언) */}
             <div className='absolute top-[10px] right-2 bg-white shadow-lg rounded-md z-50'>
-              <button className='flex items-center w-full px-4 py-2 text-left text-gray-700 hover:bg-gray-200' onClick={onModifyButtonClickHandler}>
+              <button
+                className='flex items-center w-full px-4 py-2 text-left text-gray-700 hover:bg-gray-200'
+                onClick={onEditButtonClickHandler}
+              >
                 수정하기
               </button>
-              <button className='flex items-center w-full px-4 py-2 text-left text-red-600 hover:bg-red-100' onClick={onDeleteButtonClickHandler}>
+              <button
+                className='flex items-center w-full px-4 py-2 text-left text-red-600 hover:bg-red-100'
+                onClick={onDeleteButtonClickHandler}
+              >
                 삭제하기
               </button>
             </div>
@@ -122,18 +181,26 @@ const PreAuctionDetails = () => {
       </div>
       {/* 삭제 확인 다이얼로그 */}
       {isDeleteConfirmOpen && (
-        <ConfirmationModal message='정말 삭제하시겠습니까?' onConfirm={onConfirmDeleteHandler} onCancel={() => setIsDeleteConfirmOpen(false)} />
+        <ConfirmationModal
+          message='정말 삭제하시겠습니까?'
+          onConfirm={handleConfirmDelete}
+          onCancel={() => setIsDeleteConfirmOpen(false)}
+        />
       )}
       {/* 삭제 성공 메시지 */}
-      {isDeleteSuccessOpen && <SuccessModal message='아이템이 삭제되었습니다.' onClose={onCloseSuccessModalHandler} />}
+      {isDeleteSuccessOpen && (
+        <SuccessModal
+          message='아이템이 삭제되었습니다.'
+          onClose={handleCloseSuccessModal}
+        />
+      )}
     </Layout>
   );
 };
 
-export default PreAuctionDetails;
+export default PreAuction;
 
 export const loader: LoaderFunction<number> = async ({ params }) => {
   const { preAuctionId } = params;
-
-  return preAuctionId;
+  return Number(preAuctionId);
 };


### PR DESCRIPTION
## 💡 작업 내용

- [x] 판매자/구매자일 경우 각각의 footer 가 다르게 나오도록 구현

## 💡 자세한 설명

- [x] 판매자일 경우 좋아요를 누른 사람의 수 / 경매로 전환하기 버튼이 노출되도록 구현
- [x] 구매자일 경우 알람 받기 버튼 노출되도록 구현 

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)
- [] 판매자일 경우 경매로 전환하기 버튼을 누르면 실제 경매로 해당 아이템이 전환되도록 구현
- [] 판매자일 경우 수정하기 버튼을 누를 경우 아이템 수정이 가능하도록 구현
- [] 구매자일 경우 좋아요 버튼을 누를 수 있도록 구현 

## ✅ 셀프 체크리스트

- [ ] PR 제목을 형식에 맞게 작성했나요?
- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [ ] 이슈는 close 했나요?
- [ ] Reviewers, Labels, Projects를 등록했나요?
- [ ] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 테스트는 잘 통과했나요?
- [ ] 불필요한 코드는 제거했나요?

closes #이슈번호
