### PR TITLE
Bug: SSE 401 에러

### DIFF
--- a/src/hooks/useSSE.ts
+++ b/src/hooks/useSSE.ts
@@ -9,14 +9,15 @@ import { useNavigate } from 'react-router-dom';
 
 export const useSSE = <T>(url: string) => {
   const [state, setState] = useState<T[]>([]);
+  const navigate = useNavigate();
+  const isLogin = useSelector(isLoggedIn);
+
   const EventSource = EventSourcePolyfill || NativeEventSource;
   const eventSource = useRef<null | EventSource>(null);
-  const accessToken = getToken();
-  const isLogin = useSelector(isLoggedIn);
-  const navigate = useNavigate();
 
   useEffect(() => {
     const fetchSSE = () => {
+      const accessToken = getToken();
       eventSource.current = new EventSource(`${import.meta.env.VITE_API_URL}${url}`, {
         headers: {
           Authorization: `Bearer ${accessToken}`,
@@ -29,7 +30,7 @@ export const useSSE = <T>(url: string) => {
         try {
           await refreshToken();
           eventSource.current?.close();
-          setTimeout(fetchSSE, 3000);
+          setTimeout(fetchSSE, 1000);
         } catch (error) {
           await logout();
           navigate('/login');


### PR DESCRIPTION
## 💡 작업 내용

 SSE 연결 종료 후 새로운 access token을 발급받지만, 재연결 요청에는 새로 생성된 토큰이 반영되지 않아 만료된 토큰으로 인해 401 에러 발생.

- [x] fetchSSE 함수 실행할 때마다 getToken함수 실행해서 최신 access token 사용.
- [x] 재연결 지연시간을 1초로 단축, 3초는 너무 길다고 판단. 

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #113 
