### PR TITLE
fix: footer notification query를 login 상황에서만 실행

### DIFF
--- a/src/components/navigation/Navigation.tsx
+++ b/src/components/navigation/Navigation.tsx
@@ -1,5 +1,6 @@
 import { navIcons } from '@/constants/navIcons';
 import { useNavigate } from 'react-router-dom';
+import { useGetNotifications } from '../notification/queries';
 
 const NavigationItem = ({
   name,
@@ -10,7 +11,7 @@ const NavigationItem = ({
   name: string;
   active: boolean;
   onClick: () => void;
-  unreadNotificationsCount?: number;
+  unreadNotificationsCount: number;
 }) => {
   const iconSrc = navIcons[name][active ? 'on' : 'off'];
   const notificationCondition = name === 'notification' && unreadNotificationsCount > 0;
@@ -26,30 +27,13 @@ const NavigationItem = ({
 };
 
 const Navigation = ({ active }: { active: string }) => {
-  // const token = getToken();
   const navigate = useNavigate();
-  // if (!token) {
-  //   return (
-  //     <nav className="flex items-center h-full">
-  //       {Object.entries(navIcons).map(([name, value]) => (
-  //         <NavigationItem
-  //           key={name}
-  //           name={name}
-  //           active={active === name}
-  //           onClick={() => {
-  //             navigate(value.path);
-  //           }}
-  //         />
-  //       ))}
-  //     </nav>
-  //   );
-  // }
+  const { notifications } = useGetNotifications();
 
-  // const { notifications } = useGetNotifications();
-  // const unreadNotificationsCount = notifications?.reduce(
-  //   (acc, cur) => (!cur.isRead ? acc + 1 : acc),
-  //   0,
-  // );
+  const unreadNotificationsCount = notifications ? notifications.reduce(
+    (acc, cur) => (!cur.isRead ? acc + 1 : acc),
+    0,
+  ) : 0
 
   return (
     <nav className='flex items-center h-full'>
@@ -61,6 +45,7 @@ const Navigation = ({ active }: { active: string }) => {
           onClick={() => {
             navigate(value.path);
           }}
+          unreadNotificationsCount={unreadNotificationsCount}
         />
       ))}
     </nav>

--- a/src/components/notification/queries.ts
+++ b/src/components/notification/queries.ts
@@ -1,11 +1,16 @@
 import { UseMutateFunction, useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
 
-import { API_END_POINT } from '@/constants/api';
-import type { INotification } from 'Notification';
 import { httpClient } from '@/api/axios';
+import { API_END_POINT } from '@/constants/api';
 import { queryKeys } from '@/constants/queryKeys';
+import { isLoggedIn } from '@/store/authSlice';
+import type { INotification } from 'Notification';
+import { useSelector } from 'react-redux';
 
 export const useGetNotifications = () => {
+  const isLogin = useSelector(isLoggedIn);
+  if (!isLogin) return { notifications: [] };
+
   const getNotifications = async (): Promise<INotification[]> => {
     const response = await httpClient.get(`${API_END_POINT.NOTIFICATIONS}`);
 


### PR DESCRIPTION
## 💡 작업 내용

- [x] footer에 있는 notification get query를 login 상황에서만 실행한다.

## 💡 자세한 설명

- useGetNotifications Hook내에서 로그인 여부를 판단하여 로그인되어있지 않으면 API 요청하지 않고 빈 배열 리턴한다.

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #73 
