### PR TITLE
Feat: 경매 상세/사전 경매 상세 페이지 구현 완료

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@reduxjs/toolkit": "^2.2.6",
         "@tanstack/react-query": "^5.51.11",
         "@tanstack/react-query-devtools": "^5.51.11",
+        "@tosspayments/tosspayments-sdk": "^2.3.2",
         "axios": "^1.7.2",
         "class-variance-authority": "^0.7.0",
         "classnames": "^2.5.1",
@@ -2406,6 +2407,11 @@
       "peerDependencies": {
         "@testing-library/dom": ">=7.21.4"
       }
+    },
+    "node_modules/@tosspayments/tosspayments-sdk": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@tosspayments/tosspayments-sdk/-/tosspayments-sdk-2.3.2.tgz",
+      "integrity": "sha512-8Sq1cMc4HrxF4zaL213D51epQM7P5p7Tq/iLARooX8SMSY/16MVs8NUuIcmO1dbfpcBaX10wLwYSOZcL4ZGRtw=="
     },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@reduxjs/toolkit": "^2.2.6",
     "@tanstack/react-query": "^5.51.11",
     "@tanstack/react-query-devtools": "^5.51.11",
+    "@tosspayments/tosspayments-sdk": "^2.3.2",
     "axios": "^1.7.2",
     "class-variance-authority": "^0.7.0",
     "classnames": "^2.5.1",

--- a/src/@types/AuctionDetails.d.ts
+++ b/src/@types/AuctionDetails.d.ts
@@ -25,4 +25,12 @@ declare module 'AuctionDetails' {
     likeCount: number;
     isLiked: boolean;
   }
+
+  export interface IAuctionRegisterRequest {
+    productName: string;
+    description: string;
+    category: string;
+    minPrice: number;
+    auctionRegisterType: string;
+  }
 }

--- a/src/@types/AuctionDetails.d.ts
+++ b/src/@types/AuctionDetails.d.ts
@@ -25,12 +25,4 @@ declare module 'AuctionDetails' {
     likeCount: number;
     isLiked: boolean;
   }
-
-  export interface IAuctionRegisterRequest {
-    productName: string;
-    description: string;
-    category: string;
-    minPrice: number;
-    auctionRegisterType: string;
-  }
 }

--- a/src/components/details/BuyersFooter.tsx
+++ b/src/components/details/BuyersFooter.tsx
@@ -1,8 +1,8 @@
-import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
-import Button from '@/components/common/Button';
-import { AiOutlineHeart, AiFillHeart } from 'react-icons/ai';
-import { useLikeAuctionItem, useCancelBid } from '@/components/details/queries';
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import Button from "@/components/common/Button";
+import { AiOutlineHeart, AiFillHeart } from "react-icons/ai";
+import { useLikeAuctionItem, useCancelBid } from "@/components/details/queries";
 
 interface BuyersFooterProps {
   auctionId: number;
@@ -47,38 +47,38 @@ const BuyersFooter = ({
 
   const onCancelBidHandler = () => {
     cancelBid(bidId);
-    navigate('/');
+    navigate("/");
   };
 
   const HeartIcon = isLiked ? AiFillHeart : AiOutlineHeart;
-  const heartColor = isLiked ? 'text-red-500' : 'text-gray-500';
+  const heartColor = isLiked ? "text-red-500" : "text-gray-500";
 
   if (isSeller) return null;
 
-  if (status === 'PENDING') {
+  if (status === "PENDING") {
     return (
-      <div className='flex items-center flex-1 h-full gap-2'>
+      <div className="flex items-center flex-1 h-full gap-2">
         <HeartIcon className={`text-xl ${heartColor}`} />
-        <span className='text-gray-600'>{`${currentLikeCount}명`}</span>
+        <span className="text-gray-600">{`${currentLikeCount}명`}</span>
         <Button
-          type='button'
-          className='flex-[2] h-full'
-          color='cheeseYellow'
+          type="button"
+          className="flex-[2] h-full"
+          color="cheeseYellow"
           onClick={onToggleNotificationHandler}
         >
-          {isLiked ? '알림 신청 완료' : '오픈 알림 받기'}
+          {isLiked ? "알림 신청 완료" : "오픈 알림 받기"}
         </Button>
       </div>
     );
   }
 
-  if (status === 'PROCEEDING' && !isParticipated) {
+  if (status === "PROCEEDING" && !isParticipated) {
     return (
-      <div className='flex items-center flex-1 h-full gap-2'>
+      <div className="flex items-center flex-1 h-full gap-2">
         <Button
-          type='button'
-          className='flex-[2] h-full'
-          color='cheeseYellow'
+          type="button"
+          className="flex-[2] h-full"
+          color="cheeseYellow"
           onClick={onMoveToBidHandler}
         >
           경매 참여하기
@@ -88,25 +88,25 @@ const BuyersFooter = ({
   }
 
   if (
-    status === 'PROCEEDING' &&
+    status === "PROCEEDING" &&
     isParticipated &&
     remainingBidCount &&
     remainingBidCount > 0
   ) {
     return (
-      <div className='flex items-center justify-between p-2 rounded-lg'>
+      <div className="flex items-center justify-between p-2 rounded-lg">
         <Button
-          type='button'
-          color='white'
-          className='flex-1 h-full'
-          onClick={onCancelBidHandler} // Call the handler here
+          type="button"
+          color="white"
+          className="flex-1 h-full transition-colors rounded text-button active:bg-black"
+          onClick={onCancelBidHandler}
         >
           참여 취소
         </Button>
         <Button
-          type='button'
-          className='flex-[2] h-full'
-          color='cheeseYellow'
+          type="button"
+          className="flex-[2] h-full"
+          color="cheeseYellow"
           onClick={onMoveToBidHandler}
         >
           금액 수정({remainingBidCount}회 가능)
@@ -115,22 +115,27 @@ const BuyersFooter = ({
     );
   }
 
-  if (status === 'PROCEEDING' && isParticipated && remainingBidCount === 0) {
+  if (status === "PROCEEDING" && isParticipated && remainingBidCount === 0) {
     return (
-      <div className='flex items-center justify-between p-2 rounded-lg'>
-        <button className='px-4 py-2 text-gray-600 border border-gray-400 rounded-lg'>
+      <div className="flex items-center justify-between p-2 rounded-lg">
+        <Button
+          type="button"
+          color="white"
+          className="flex-1 h-full transition-colors rounded text-button active:bg-black"
+          onClick={onCancelBidHandler}
+        >
           참여 취소
-        </button>
-        <Button type='button' className='px-4 py-2 text-gray-600disabled:'>
+        </Button>
+        <Button type="button" className="px-4 py-2 text-gray-600 disabled:">
           금액 수정(소진)
         </Button>
       </div>
     );
   }
 
-  if (status === 'ENDED') {
+  if (status === "ENDED") {
     return (
-      <div className='p-2 text-center bg-gray-300 rounded-lg'>종료된 경매</div>
+      <div className="p-2 text-center bg-gray-300 rounded-lg">종료된 경매</div>
     );
   }
 

--- a/src/components/details/BuyersFooter.tsx
+++ b/src/components/details/BuyersFooter.tsx
@@ -14,7 +14,14 @@ interface BuyersFooterProps {
   remainingBidCount?: number;
 }
 
-const BuyersFooter = ({ auctionId, isSeller, status, likeCount = 0, isParticipated, remainingBidCount }: BuyersFooterProps) => {
+const BuyersFooter = ({
+  auctionId,
+  isSeller,
+  status,
+  likeCount = 0,
+  isParticipated,
+  remainingBidCount,
+}: BuyersFooterProps) => {
   const navigate = useNavigate();
   const { mutate } = useLikeAuctionItem();
 
@@ -46,7 +53,12 @@ const BuyersFooter = ({ auctionId, isSeller, status, likeCount = 0, isParticipat
       <div className='flex items-center flex-1 h-full gap-2'>
         <HeartIcon className={`text-xl ${heartColor}`} />
         <span className='text-gray-600'>{`${currentLikeCount}명`}</span>
-        <Button type='button' className='flex-[2] h-full' color='cheeseYellow' onClick={onToggleNotificationHandler}>
+        <Button
+          type='button'
+          className='flex-[2] h-full'
+          color='cheeseYellow'
+          onClick={onToggleNotificationHandler}
+        >
           {isLiked ? '알림 신청 완료' : '오픈 알림 받기'}
         </Button>
       </div>
@@ -56,18 +68,37 @@ const BuyersFooter = ({ auctionId, isSeller, status, likeCount = 0, isParticipat
   if (status === 'PROCEEDING' && !isParticipated) {
     return (
       <div className='flex items-center flex-1 h-full gap-2'>
-        <Button type='button' className='flex-[2] h-full' color='cheeseYellow' onClick={onMoveToBidHandler}>
+        <Button
+          type='button'
+          className='flex-[2] h-full'
+          color='cheeseYellow'
+          onClick={onMoveToBidHandler}
+        >
           경매 참여하기
         </Button>
       </div>
     );
   }
 
-  if (status === 'PROCEEDING' && isParticipated && remainingBidCount && remainingBidCount > 0) {
+  if (
+    status === 'PROCEEDING' &&
+    isParticipated &&
+    remainingBidCount &&
+    remainingBidCount > 0
+  ) {
     return (
       <div className='flex items-center justify-between p-2 rounded-lg'>
-        <button className='px-4 py-2 text-gray-600 border border-gray-400 rounded-lg'>참여 취소</button>
-        <button className='px-4 py-2 text-white transition-colors bg-orange-500 rounded-lg hover:bg-orange-600'>금액 수정({remainingBidCount}회 가능)</button>
+        <button className='px-4 py-2 text-gray-600 border border-gray-400 rounded-lg'>
+          참여 취소
+        </button>
+        <Button
+          type='button'
+          className='flex-[2] h-full'
+          color='cheeseYellow'
+          onClick={onMoveToBidHandler}
+        >
+          금액 수정({remainingBidCount}회 가능)
+        </Button>
       </div>
     );
   }
@@ -75,14 +106,20 @@ const BuyersFooter = ({ auctionId, isSeller, status, likeCount = 0, isParticipat
   if (status === 'PROCEEDING' && isParticipated && remainingBidCount === 0) {
     return (
       <div className='flex items-center justify-between p-2 rounded-lg'>
-        <button className='px-4 py-2 text-gray-600 border border-gray-400 rounded-lg'>참여 취소</button>
-        <button className='px-4 py-2 text-white bg-gray-400 rounded-lg cursor-not-allowed'>금액 수정(소진)</button>
+        <button className='px-4 py-2 text-gray-600 border border-gray-400 rounded-lg'>
+          참여 취소
+        </button>
+        <button className='px-4 py-2 text-white bg-gray-400 rounded-lg cursor-not-allowed'>
+          금액 수정(소진)
+        </button>
       </div>
     );
   }
 
   if (status === 'ENDED') {
-    return <div className='p-2 text-center bg-gray-300 rounded-lg'>종료된 경매</div>;
+    return (
+      <div className='p-2 text-center bg-gray-300 rounded-lg'>종료된 경매</div>
+    );
   }
 
   return null;

--- a/src/components/details/BuyersFooter.tsx
+++ b/src/components/details/BuyersFooter.tsx
@@ -1,12 +1,12 @@
-/* eslint-disable prettier/prettier */
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Button from '@/components/common/Button';
 import { AiOutlineHeart, AiFillHeart } from 'react-icons/ai';
-import { useLikeAuctionItem } from '@/components/details/queries';
+import { useLikeAuctionItem, useCancelBid } from '@/components/details/queries';
 
 interface BuyersFooterProps {
   auctionId: number;
+  bidId: number;
   isSeller: boolean;
   status: string;
   likeCount?: number;
@@ -16,6 +16,7 @@ interface BuyersFooterProps {
 
 const BuyersFooter = ({
   auctionId,
+  bidId,
   isSeller,
   status,
   likeCount = 0,
@@ -23,7 +24,8 @@ const BuyersFooter = ({
   remainingBidCount,
 }: BuyersFooterProps) => {
   const navigate = useNavigate();
-  const { mutate } = useLikeAuctionItem();
+  const { mutate: likeAuctionItem } = useLikeAuctionItem();
+  const { mutate: cancelBid } = useCancelBid(); // Call the hook here
 
   const [currentLikeCount, setCurrentLikeCount] = useState<number>(likeCount);
   const [isLiked, setIsLiked] = useState<boolean>(isParticipated);
@@ -33,7 +35,7 @@ const BuyersFooter = ({
   };
 
   const onToggleNotificationHandler = () => {
-    mutate(auctionId);
+    likeAuctionItem(auctionId);
     if (!isLiked) {
       setCurrentLikeCount((prev) => prev + 1);
       setIsLiked(true);
@@ -41,6 +43,11 @@ const BuyersFooter = ({
       setCurrentLikeCount((prev) => (prev > 0 ? prev - 1 : 0));
       setIsLiked(false);
     }
+  };
+
+  const onCancelBidHandler = () => {
+    cancelBid(bidId);
+    navigate('/');
   };
 
   const HeartIcon = isLiked ? AiFillHeart : AiOutlineHeart;
@@ -88,9 +95,14 @@ const BuyersFooter = ({
   ) {
     return (
       <div className='flex items-center justify-between p-2 rounded-lg'>
-        <button className='px-4 py-2 text-gray-600 border border-gray-400 rounded-lg'>
+        <Button
+          type='button'
+          color='white'
+          className='flex-1 h-full'
+          onClick={onCancelBidHandler} // Call the handler here
+        >
           참여 취소
-        </button>
+        </Button>
         <Button
           type='button'
           className='flex-[2] h-full'

--- a/src/components/details/BuyersFooter.tsx
+++ b/src/components/details/BuyersFooter.tsx
@@ -6,7 +6,7 @@ import { useLikeAuctionItem, useCancelBid } from '@/components/details/queries';
 
 interface BuyersFooterProps {
   auctionId: number;
-  bidId: number;
+  bidId?: number;
   isSeller: boolean;
   status: string;
   likeCount?: number;
@@ -16,7 +16,7 @@ interface BuyersFooterProps {
 
 const BuyersFooter = ({
   auctionId,
-  bidId,
+  bidId = 0,
   isSeller,
   status,
   likeCount = 0,

--- a/src/components/details/BuyersFooter.tsx
+++ b/src/components/details/BuyersFooter.tsx
@@ -121,9 +121,9 @@ const BuyersFooter = ({
         <button className='px-4 py-2 text-gray-600 border border-gray-400 rounded-lg'>
           참여 취소
         </button>
-        <button className='px-4 py-2 text-white bg-gray-400 rounded-lg cursor-not-allowed'>
+        <Button type='button' className='px-4 py-2 text-gray-600disabled:'>
           금액 수정(소진)
-        </button>
+        </Button>
       </div>
     );
   }

--- a/src/components/details/SellersFooter.tsx
+++ b/src/components/details/SellersFooter.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import Button from '@/components/common/Button';
 import { AiOutlineHeart } from 'react-icons/ai';
 import { useConvertToAuction } from './queries';
+import { useNavigate } from 'react-router-dom';
 
 interface SellersFooterProps {
   isSeller: boolean;
@@ -18,8 +19,10 @@ const SellersFooter: React.FC<SellersFooterProps> = ({
   auctionId,
 }) => {
   const { mutate: convertToAuction } = useConvertToAuction();
+  const navigate = useNavigate();
   const onConvertClickHandler = () => {
     convertToAuction(auctionId);
+    navigate('/');
   };
 
   if (isSeller && status === 'PROCEEDING') {

--- a/src/components/details/SellersFooter.tsx
+++ b/src/components/details/SellersFooter.tsx
@@ -2,18 +2,26 @@
 import React from 'react';
 import Button from '@/components/common/Button';
 import { AiOutlineHeart } from 'react-icons/ai';
+import { useConvertToAuction } from './queries';
 
 interface SellersFooterProps {
   isSeller: boolean;
   likeCount?: number;
   status?: string;
+  auctionId: number;
 }
 
 const SellersFooter: React.FC<SellersFooterProps> = ({
   isSeller,
   status,
   likeCount = 0,
+  auctionId,
 }) => {
+  const { mutate: convertToAuction } = useConvertToAuction();
+  const onConvertClickHandler = () => {
+    convertToAuction(auctionId);
+  };
+
   if (isSeller && status === 'PROCEEDING') {
     return (
       <div className='bg-gray-300 text-gray-600 p-4 rounded-lg text-center border border-dashed border-blue-200'>
@@ -27,7 +35,12 @@ const SellersFooter: React.FC<SellersFooterProps> = ({
       <div className='flex items-center flex-1 h-full gap-2'>
         <AiOutlineHeart className='text-xl text-gray-500' />
         <span className='text-gray-600'>{`${likeCount}명`}</span>
-        <Button type='button' className='flex-[2] h-full' color='cheeseYellow'>
+        <Button
+          type='button'
+          className='flex-[2] h-full'
+          color='cheeseYellow'
+          onClick={onConvertClickHandler}
+        >
           경매로 전환하기
         </Button>
       </div>

--- a/src/components/details/queries.ts
+++ b/src/components/details/queries.ts
@@ -1,8 +1,4 @@
-import {
-  IAuctionDetails,
-  IAuctionRegisterRequest,
-  IPreAuctionDetails,
-} from 'AuctionDetails';
+import { IAuctionDetails, IPreAuctionDetails } from 'AuctionDetails';
 import { API_END_POINT } from '@/constants/api';
 import { httpClient } from '@/api/axios';
 import { queryKeys } from '@/constants/queryKeys';
@@ -37,7 +33,7 @@ export const useConvertToAuction = (): {
         queryKey: [queryKeys.PRE_AUCTION_DETAILS, productId],
       });
       queryClient.invalidateQueries({
-        queryKey: [queryKeys.AUCTION_LIST],
+        queryKey: [queryKeys.AUCTION_LOST],
       });
     },
   });

--- a/src/components/details/queries.ts
+++ b/src/components/details/queries.ts
@@ -130,3 +130,30 @@ export const useGetPreAuctionDetails = (preAuctionId: number) => {
     preAuctionDetails,
   };
 };
+
+export const useDeletePreAuction = (): {
+  mutate: UseMutateFunction<any, Error, number, unknown>;
+} => {
+  const queryClient = useQueryClient();
+
+  const deletePreAuction = async (preAuctionId: number) => {
+    const response = await httpClient.delete(
+      `${API_END_POINT.PRE_AUCTION}/${preAuctionId}`,
+    );
+    return response.data;
+  };
+
+  const { mutate } = useMutation({
+    mutationFn: deletePreAuction,
+    onSuccess: (_, preAuctionId) => {
+      queryClient.invalidateQueries({
+        queryKey: [queryKeys.PRE_AUCTION_DETAILS, preAuctionId],
+      });
+      queryClient.invalidateQueries({
+        queryKey: [queryKeys.AUCTION_LOST],
+      });
+    },
+  });
+
+  return { mutate };
+};

--- a/src/components/details/queries.ts
+++ b/src/components/details/queries.ts
@@ -64,6 +64,33 @@ export const useLikeAuctionItem = (): {
   return { mutate };
 };
 
+export const useCancelBid = (): {
+  mutate: UseMutateFunction<any, Error, number, unknown>;
+} => {
+  const queryClient = useQueryClient();
+
+  const cancelBid = async (bidId: number) => {
+    const response = await httpClient.patch(
+      `${API_END_POINT.BID}/${bidId}/cancel`
+    );
+    return response.data;
+  };
+
+  const { mutate } = useMutation({
+    mutationFn: cancelBid,
+    onSuccess: (_, bidId) => {
+      queryClient.invalidateQueries({
+        queryKey: [queryKeys.BIDDER_LIST, bidId],
+      });
+      queryClient.invalidateQueries({
+        queryKey: [queryKeys.AUCTION_DETAILS],
+      });
+    },
+  });
+
+  return { mutate };
+};
+
 export const useGetAuctionDetails = (auctionId: number) => {
   const getAuctionDetails = async (): Promise<IAuctionDetails> => {
     const response = await httpClient.get(

--- a/src/components/details/queries.ts
+++ b/src/components/details/queries.ts
@@ -1,13 +1,57 @@
-import { IAuctionDetails, IPreAuctionDetails } from 'AuctionDetails';
-
+import {
+  IAuctionDetails,
+  IAuctionRegisterRequest,
+  IPreAuctionDetails,
+} from 'AuctionDetails';
 import { API_END_POINT } from '@/constants/api';
 import { httpClient } from '@/api/axios';
 import { queryKeys } from '@/constants/queryKeys';
-import { UseMutateFunction, useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
+import {
+  UseMutateFunction,
+  useMutation,
+  useQueryClient,
+  useSuspenseQuery,
+} from '@tanstack/react-query';
 
-export const useLikeAuctionItem = (): { mutate: UseMutateFunction<any, Error, number, unknown> } => {
+export const useConvertToAuction = (): {
+  mutate: UseMutateFunction<any, Error, number, unknown>;
+} => {
+  const queryClient = useQueryClient();
+
+  const { mutate } = useMutation({
+    mutationFn: async (productId: number) => {
+      const response = await httpClient.post(
+        `${API_END_POINT.AUCTIONS}/start`,
+        { productId }, // 객체를 직접 전달
+        {
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
+          },
+        }
+      );
+      return response.data;
+    },
+    onSuccess: (_, productId) => {
+      queryClient.invalidateQueries({
+        queryKey: [queryKeys.PRE_AUCTION_DETAILS, productId],
+      });
+      queryClient.invalidateQueries({
+        queryKey: [queryKeys.AUCTION_LIST],
+      });
+    },
+  });
+
+  return { mutate };
+};
+
+export const useLikeAuctionItem = (): {
+  mutate: UseMutateFunction<any, Error, number, unknown>;
+} => {
   const likeAuctionItem = async (auctionId: number) => {
-    const response = await httpClient.post(`${API_END_POINT.PRE_AUCTION}/${auctionId}/likes`);
+    const response = await httpClient.post(
+      `${API_END_POINT.PRE_AUCTION}/${auctionId}/likes`
+    );
     return response.data;
   };
 
@@ -15,15 +59,20 @@ export const useLikeAuctionItem = (): { mutate: UseMutateFunction<any, Error, nu
   const { mutate } = useMutation({
     mutationFn: likeAuctionItem,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: [queryKeys.PRE_AUCTION_DETAILS] });
+      queryClient.invalidateQueries({
+        queryKey: [queryKeys.PRE_AUCTION_DETAILS],
+      });
     },
   });
 
   return { mutate };
 };
+
 export const useGetAuctionDetails = (auctionId: number) => {
   const getAuctionDetails = async (): Promise<IAuctionDetails> => {
-    const response = await httpClient.get(`${API_END_POINT.AUCTIONS}/${auctionId}`);
+    const response = await httpClient.get(
+      `${API_END_POINT.AUCTIONS}/${auctionId}`
+    );
 
     return response.data;
   };
@@ -42,7 +91,9 @@ export const useGetPreAuctionDetails = (preAuctionId: number) => {
   if (!preAuctionId) return { preAuctionDetails: undefined };
 
   const getPreAuctionDetails = async (): Promise<IPreAuctionDetails> => {
-    const response = await httpClient.get(`${API_END_POINT.PRE_AUCTION}/${preAuctionId}`);
+    const response = await httpClient.get(
+      `${API_END_POINT.PRE_AUCTION}/${preAuctionId}`
+    );
 
     return response.data;
   };

--- a/src/components/details/queries.ts
+++ b/src/components/details/queries.ts
@@ -1,13 +1,13 @@
-import { IAuctionDetails, IPreAuctionDetails } from 'AuctionDetails';
-import { API_END_POINT } from '@/constants/api';
-import { httpClient } from '@/api/axios';
-import { queryKeys } from '@/constants/queryKeys';
+import { IAuctionDetails, IPreAuctionDetails } from "AuctionDetails";
+import { API_END_POINT } from "@/constants/api";
+import { httpClient } from "@/api/axios";
+import { queryKeys } from "@/constants/queryKeys";
 import {
   UseMutateFunction,
   useMutation,
   useQueryClient,
   useSuspenseQuery,
-} from '@tanstack/react-query';
+} from "@tanstack/react-query";
 
 export const useConvertToAuction = (): {
   mutate: UseMutateFunction<any, Error, number, unknown>;
@@ -18,13 +18,7 @@ export const useConvertToAuction = (): {
     mutationFn: async (productId: number) => {
       const response = await httpClient.post(
         `${API_END_POINT.AUCTIONS}/start`,
-        { productId }, // 객체를 직접 전달
-        {
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
-          },
-        }
+        productId,
       );
       return response.data;
     },
@@ -46,7 +40,7 @@ export const useLikeAuctionItem = (): {
 } => {
   const likeAuctionItem = async (auctionId: number) => {
     const response = await httpClient.post(
-      `${API_END_POINT.PRE_AUCTION}/${auctionId}/likes`
+      `${API_END_POINT.PRE_AUCTION}/${auctionId}/likes`,
     );
     return response.data;
   };
@@ -71,7 +65,7 @@ export const useCancelBid = (): {
 
   const cancelBid = async (bidId: number) => {
     const response = await httpClient.patch(
-      `${API_END_POINT.BID}/${bidId}/cancel`
+      `${API_END_POINT.BID}/${bidId}/cancel`,
     );
     return response.data;
   };
@@ -94,7 +88,7 @@ export const useCancelBid = (): {
 export const useGetAuctionDetails = (auctionId: number) => {
   const getAuctionDetails = async (): Promise<IAuctionDetails> => {
     const response = await httpClient.get(
-      `${API_END_POINT.AUCTIONS}/${auctionId}`
+      `${API_END_POINT.AUCTIONS}/${auctionId}`,
     );
 
     return response.data;
@@ -115,7 +109,7 @@ export const useGetPreAuctionDetails = (preAuctionId: number) => {
 
   const getPreAuctionDetails = async (): Promise<IPreAuctionDetails> => {
     const response = await httpClient.get(
-      `${API_END_POINT.PRE_AUCTION}/${preAuctionId}`
+      `${API_END_POINT.PRE_AUCTION}/${preAuctionId}`,
     );
 
     return response.data;

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -15,7 +15,7 @@ const Header = ({
   title,
   handleBack,
   handleModal = undefined,
-  isDisableMenuButton = false,
+  isDisableMenuButton = true,
 }: HeaderProps) => {
   const navigate = useNavigate();
   if (!handleBack) handleBack = () => navigate(-1);

--- a/src/components/payment/PaymentForm.tsx
+++ b/src/components/payment/PaymentForm.tsx
@@ -1,71 +1,92 @@
 /* eslint-disable prettier/prettier */
 // src/components/PaymentForm.tsx
 
-import React, { useState } from 'react';
-import { loadTossPayments } from '@tosspayments/tosspayments-sdk';
-import { toast } from 'sonner';
+// import React, { useState, useEffect } from 'react';
+// import { loadTossPayments } from '@tosspayments/tosspayments-sdk';
+// import { toast } from 'sonner';
 
 const PaymentForm: React.FC = () => {
-  const [amount, setAmount] = useState<number>(0);
-  const [orderId, setOrderId] = useState<string>('');
-  const [orderName, setOrderName] = useState<string>('');
-  const [error, setError] = useState<string | null>(null);
-  const tossPayments = await loadTossPayment(
-    import.meta.env.VITE_TOSS_CLIENT_KEY
-  );
-
-  const handlePayment = async (e: React.FormEvent) => {
-    e.preventDefault();
-
-    const paymentData: PaymentRequest = {
-      amount,
-      orderId,
-      orderName,
-      successUrl: 'https://yourdomain.com/payment-success',
-      failUrl: 'https://yourdomain.com/payment-fail',
-      // 필요한 다른 필드들 추가
-    };
-
-    try {
-      const response = await initiatePayment(paymentData);
-      console.log('결제 시작:', response);
-      // 성공 시 처리 (예: successUrl로 리디렉션)
-    } catch (err: any) {
-      setError(err.message);
-      toast.error(err.message); // 에러 메시지를 사용자에게 표시
-    }
-  };
-
-  return (
-    <form onSubmit={handlePayment}>
-      <div>
-        <label>금액:</label>
-        <input
-          type='number'
-          value={amount}
-          onChange={(e) => setAmount(parseInt(e.target.value, 10))}
-        />
-      </div>
-      <div>
-        <label>주문 ID:</label>
-        <input
-          type='text'
-          value={orderId}
-          onChange={(e) => setOrderId(e.target.value)}
-        />
-      </div>
-      <div>
-        <label>주문명:</label>
-        <input
-          type='text'
-          value={orderName}
-          onChange={(e) => setOrderName(e.target.value)}
-        />
-      </div>
-      {error && <p style={{ color: 'red' }}>{error}</p>}
-      <button type='submit'>결제하기</button>
-    </form>
-  );
+  return <></>;
 };
+//   const [amount, setAmount] = useState<number>(0);
+//   const [orderId, setOrderId] = useState<string>('');
+//   const [orderName, setOrderName] = useState<string>('');
+//   const [error, setError] = useState<string | null>(null);
+//   const [tossPayments, setTossPayments] = useState<any>(null);
+
+//   useEffect(() => {
+//     const initializeTossPayments = async () => {
+//       const toss = await loadTossPayments(import.meta.env.VITE_TOSS_CLIENT_KEY);
+//       setTossPayments(toss);
+//     };
+//     initializeTossPayments();
+//   }, []);
+
+//   console.log(tossPayments);
+
+//   const handlePayment = async (e: React.FormEvent) => {
+//     e.preventDefault();
+
+//     const paymentData = {
+//       amount,
+//       orderId,
+//       orderName,
+//       failUrl: 'https://yourdomain.com/payment-fail',
+//       // 필요한 다른 필드들 추가
+//     };
+
+//     try {
+//       const response = await initiatePayment(paymentData);
+//       console.log(response, paymentData);
+//     } catch (err: any) {
+//       setError(err.message);
+//       toast.error(err.message); // 에러 메시지를 사용자에게 표시
+//     }
+//   };
+
+//   return (
+//     <form onSubmit={handlePayment}>
+//       <div>
+//         <label htmlFor='amount'>금액:</label>
+//         <input
+//           id='amount'
+//           type='number'
+//           value={amount}
+//           onChange={(e) => setAmount(parseInt(e.target.value, 10))}
+//         />
+//       </div>
+//       <div>
+//         <label htmlFor='orderId'>주문 ID:</label>
+//         <input
+//           id='orderId'
+//           type='text'
+//           value={orderId}
+//           onChange={(e) => setOrderId(e.target.value)}
+//         />
+//       </div>
+//       <div>
+//         <label htmlFor='orderName'>주문명:</label>
+//         <input
+//           type='text'
+//           value={orderName}
+//           onChange={(e) => setOrderName(e.target.value)}
+//         />
+//       </div>
+//       {error && <p style={{ color: 'red' }}>{error}</p>}
+//       <button type='submit'>결제하기</button>
+//     </form>
+//   );
+// };
+
+// const initiatePayment = async (paymentData: any) => {
+//   // Implement the payment initiation logic here
+//   // This is a placeholder function
+//   return new Promise((resolve, reject) => {
+//     setTimeout(() => {
+//       resolve('Payment successful');
+//       console.log(reject);
+//     }, 1000);
+//   });
+// };
 
 export default PaymentForm;

--- a/src/components/payment/PaymentForm.tsx
+++ b/src/components/payment/PaymentForm.tsx
@@ -1,0 +1,71 @@
+/* eslint-disable prettier/prettier */
+// src/components/PaymentForm.tsx
+
+import React, { useState } from 'react';
+import { loadTossPayments } from '@tosspayments/tosspayments-sdk';
+import { toast } from 'sonner';
+
+const PaymentForm: React.FC = () => {
+  const [amount, setAmount] = useState<number>(0);
+  const [orderId, setOrderId] = useState<string>('');
+  const [orderName, setOrderName] = useState<string>('');
+  const [error, setError] = useState<string | null>(null);
+  const tossPayments = await loadTossPayment(
+    import.meta.env.VITE_TOSS_CLIENT_KEY
+  );
+
+  const handlePayment = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    const paymentData: PaymentRequest = {
+      amount,
+      orderId,
+      orderName,
+      successUrl: 'https://yourdomain.com/payment-success',
+      failUrl: 'https://yourdomain.com/payment-fail',
+      // 필요한 다른 필드들 추가
+    };
+
+    try {
+      const response = await initiatePayment(paymentData);
+      console.log('결제 시작:', response);
+      // 성공 시 처리 (예: successUrl로 리디렉션)
+    } catch (err: any) {
+      setError(err.message);
+      toast.error(err.message); // 에러 메시지를 사용자에게 표시
+    }
+  };
+
+  return (
+    <form onSubmit={handlePayment}>
+      <div>
+        <label>금액:</label>
+        <input
+          type='number'
+          value={amount}
+          onChange={(e) => setAmount(parseInt(e.target.value, 10))}
+        />
+      </div>
+      <div>
+        <label>주문 ID:</label>
+        <input
+          type='text'
+          value={orderId}
+          onChange={(e) => setOrderId(e.target.value)}
+        />
+      </div>
+      <div>
+        <label>주문명:</label>
+        <input
+          type='text'
+          value={orderName}
+          onChange={(e) => setOrderName(e.target.value)}
+        />
+      </div>
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+      <button type='submit'>결제하기</button>
+    </form>
+  );
+};
+
+export default PaymentForm;

--- a/src/constants/route.ts
+++ b/src/constants/route.ts
@@ -21,6 +21,7 @@ const ROUTERS = Object.freeze({
   ADDRESSBOOK: '/addressbook',
   BID: '/auctions/bid/:auctionId',
   FINAL_BIDDER_LIST: '/auctions/:auctionId/final-bidder-list',
+  PAYMENT: '/payment/:auctionId'
 });
 
 export default ROUTERS;

--- a/src/pages/AuctionDetails.tsx
+++ b/src/pages/AuctionDetails.tsx
@@ -39,6 +39,8 @@ const AuctionDetails = () => {
     return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
   };
 
+  console.log(auctionDetails);
+
   return (
     <Layout>
       <Layout.Header
@@ -151,6 +153,7 @@ const AuctionDetails = () => {
           ) : (
             <BuyersFooter
               auctionId={auctionId}
+              bidId={auctionDetails.bidId ?? 0}
               isSeller={auctionDetails.isSeller ?? false}
               status={auctionDetails.status ?? ''}
               isParticipated={auctionDetails.isParticipated ?? false}

--- a/src/pages/AuctionDetails.tsx
+++ b/src/pages/AuctionDetails.tsx
@@ -14,7 +14,10 @@ import { formatCurrencyWithWon } from '@/utils/formatCurrencyWithWon';
 
 const AuctionDetails = () => {
   const auctionId = useLoaderData() as number;
-  const { auctionDetails } = useGetAuctionDetails(auctionId) || {};
+  const { auctionDetails } = useGetAuctionDetails(auctionId);
+  if (!auctionDetails) {
+    throw new Error('해당 물품을 찾을 수 없습니다.');
+  }
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isTimerFixed, _setIsTimerFixed] = useState(false);
   const [isPreAuction, _setIsPreAuction] = useState(false);
@@ -89,7 +92,7 @@ const AuctionDetails = () => {
                       <img src={Price} alt='Price' />
                     </span>
                     시작가
-                    <span className='font-bold p'>
+                    <span className='font-bold'>
                       {formatCurrencyWithWon(auctionDetails?.minPrice || 0)}원
                     </span>
                   </span>

--- a/src/pages/AuctionDetails.tsx
+++ b/src/pages/AuctionDetails.tsx
@@ -14,7 +14,7 @@ import { formatCurrencyWithWon } from '@/utils/formatCurrencyWithWon';
 
 const AuctionDetails = () => {
   const auctionId = useLoaderData() as number;
-  const { auctionDetails } = useGetAuctionDetails(auctionId);
+  const { auctionDetails } = useGetAuctionDetails(auctionId) || {};
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isTimerFixed, _setIsTimerFixed] = useState(false);
   const [isPreAuction, _setIsPreAuction] = useState(false);
@@ -41,7 +41,7 @@ const AuctionDetails = () => {
         title='제품 상세'
         handleBack={handleBackClick}
         handleModal={toggleMenu}
-        isDisableMenuButton={!auctionDetails.isSeller}
+        isDisableMenuButton={!auctionDetails?.isSeller}
       />
       {/* 메인 컨텐츠가 스크롤 가능하도록 수정 */}
       <div className='relative flex flex-col h-screen overflow-hidden'>
@@ -50,8 +50,8 @@ const AuctionDetails = () => {
           <div className='relative w-full'>
             <div className='w-full mb-2'>
               <img
-                src={auctionDetails.imageUrls[0]}
-                alt={auctionDetails.productName}
+                src={auctionDetails?.imageUrls?.[0] || ''}
+                alt={auctionDetails?.productName || ''}
                 className='object-cover w-full h-auto'
               />
             </div>
@@ -62,7 +62,7 @@ const AuctionDetails = () => {
                 className={`bg-white z-10 py-1 ${isTimerFixed ? 'fixed top-0 left-0 right-0' : ''}`}
               >
                 <ProgressBar
-                  initialTimeRemaining={auctionDetails.timeRemaining}
+                  initialTimeRemaining={auctionDetails?.timeRemaining || 0}
                   totalTime={totalTime} // Should be 86400
                 />
               </div>
@@ -77,11 +77,11 @@ const AuctionDetails = () => {
                 <div className='mt-2 mb-2 flex flex-row items-center'>
                   <div className='rounded-[50%] w-8 h-8 bg-slate-500' />
                   <p className='ml-3 text-black'>
-                    {auctionDetails.sellerNickname}
+                    {auctionDetails?.sellerNickname || ''}
                   </p>
                 </div>
                 <p className='mt-2 mb-2 text-2xl font-bold'>
-                  {auctionDetails.productName}
+                  {auctionDetails?.productName || ''}
                 </p>
                 <p className='mt-2 mb-2 text-sm text-gray-500'>
                   <span className='inline-flex items-center'>
@@ -90,7 +90,7 @@ const AuctionDetails = () => {
                     </span>
                     시작가
                     <span className='font-bold p'>
-                      {formatCurrencyWithWon(auctionDetails.minPrice)}원
+                      {formatCurrencyWithWon(auctionDetails?.minPrice || 0)}원
                     </span>
                   </span>
                 </p>
@@ -105,8 +105,8 @@ const AuctionDetails = () => {
                     <span className='ml-1'>나의 참여 금액</span>
                   </div>
                   <p className='text-xl font-bold text-gray-800'>
-                    {auctionDetails.isParticipated
-                      ? `${formatCurrencyWithWon(auctionDetails.bidAmount)}원`
+                    {auctionDetails?.isParticipated
+                      ? `${formatCurrencyWithWon(auctionDetails?.bidAmount || 0)}원`
                       : '참여 전'}
                   </p>
                 </div>
@@ -121,8 +121,8 @@ const AuctionDetails = () => {
                     <p className='mb-1 text-sm text-gray-500'>참여 인원</p>
                   </div>
                   <p className='text-lg font-bold'>
-                    {auctionDetails.participantCount
-                      ? `${auctionDetails.participantCount}명`
+                    {auctionDetails?.participantCount
+                      ? `${auctionDetails?.participantCount}명`
                       : '0명'}
                   </p>
                 </div>
@@ -132,7 +132,7 @@ const AuctionDetails = () => {
 
           {/* 상품 설명 */}
           <div className='px-4 mb-4 overflow-y-auto text-sm text-gray-700'>
-            <p>{auctionDetails.description}</p>
+            <p>{auctionDetails?.description || ''}</p>
           </div>
         </Layout.Main>
         {/* 화면 하단에 고정된 Footer */}
@@ -140,17 +140,17 @@ const AuctionDetails = () => {
           {auctionDetails && auctionDetails.isSeller ? (
             <SellersFooter
               auctionId={auctionId}
-              isSeller={auctionDetails.isSeller}
-              status={auctionDetails.status}
+              isSeller={auctionDetails?.isSeller || false}
+              status={auctionDetails?.status || ''}
             />
           ) : (
             <BuyersFooter
               auctionId={auctionId}
-              bidId={auctionDetails.bidId ?? 0}
-              isSeller={auctionDetails.isSeller ?? false}
-              status={auctionDetails.status ?? ''}
-              isParticipated={auctionDetails.isParticipated ?? false}
-              remainingBidCount={auctionDetails.remainingBidCount ?? 0}
+              bidId={auctionDetails?.bidId ?? 0}
+              isSeller={auctionDetails?.isSeller ?? false}
+              status={auctionDetails?.status ?? ''}
+              isParticipated={auctionDetails?.isParticipated ?? false}
+              remainingBidCount={auctionDetails?.remainingBidCount ?? 0}
             />
           )}
         </Layout.Footer>

--- a/src/pages/AuctionDetails.tsx
+++ b/src/pages/AuctionDetails.tsx
@@ -10,6 +10,7 @@ import Price from '@/assets/icons/price.svg';
 import ProgressBar from '@/components/details/ProgressBar';
 import SellersFooter from '@/components/details/SellersFooter';
 import { useGetAuctionDetails } from '@/components/details/queries';
+import { formatCurrencyWithWon } from '@/utils/formatCurrencyWithWon';
 
 const AuctionDetails = () => {
   const auctionId = useLoaderData() as number;
@@ -32,11 +33,6 @@ const AuctionDetails = () => {
 
   const closeMenu = () => {
     setIsMenuOpen(false);
-  };
-
-  // 세자리 단위로 콤마를 찍어주는 함수
-  const numberWithCommas = (x: number) => {
-    return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
   };
 
   return (
@@ -94,7 +90,7 @@ const AuctionDetails = () => {
                     </span>
                     시작가
                     <span className='font-bold p'>
-                      {numberWithCommas(Number(auctionDetails.minPrice))}원
+                      {formatCurrencyWithWon(auctionDetails.minPrice)}원
                     </span>
                   </span>
                 </p>
@@ -110,7 +106,7 @@ const AuctionDetails = () => {
                   </div>
                   <p className='text-xl font-bold text-gray-800'>
                     {auctionDetails.isParticipated
-                      ? `${numberWithCommas(Number(auctionDetails.bidAmount))}원`
+                      ? `${formatCurrencyWithWon(auctionDetails.bidAmount)}원`
                       : '참여 전'}
                   </p>
                 </div>

--- a/src/pages/AuctionDetails.tsx
+++ b/src/pages/AuctionDetails.tsx
@@ -39,8 +39,6 @@ const AuctionDetails = () => {
     return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
   };
 
-  console.log(auctionDetails);
-
   return (
     <Layout>
       <Layout.Header
@@ -56,7 +54,7 @@ const AuctionDetails = () => {
           <div className='relative w-full'>
             <div className='w-full mb-2'>
               <img
-                src={`${auctionDetails.imageUrls[0]}`}
+                src={auctionDetails.imageUrls[0]}
                 alt={auctionDetails.productName}
                 className='object-cover w-full h-auto'
               />
@@ -87,8 +85,7 @@ const AuctionDetails = () => {
                   </p>
                 </div>
                 <p className='mt-2 mb-2 text-2xl font-bold'>
-                  {auctionDetails.productName ||
-                    '[ERROR] 이름이 등록되지 않았어요!'}
+                  {auctionDetails.productName}
                 </p>
                 <p className='mt-2 mb-2 text-sm text-gray-500'>
                   <span className='inline-flex items-center'>

--- a/src/pages/AuctionDetails.tsx
+++ b/src/pages/AuctionDetails.tsx
@@ -45,7 +45,7 @@ const AuctionDetails = () => {
         title='제품 상세'
         handleBack={handleBackClick}
         handleModal={toggleMenu}
-        isDisableMenuButton // 메뉴 버튼을 숨기고 싶을 때 true로 설정
+        isDisableMenuButton={!auctionDetails.isSeller}
       />
       {/* 메인 컨텐츠가 스크롤 가능하도록 수정 */}
       <div className='relative flex flex-col h-screen overflow-hidden'>
@@ -53,11 +53,18 @@ const AuctionDetails = () => {
           {/* 상품 이미지 영역 */}
           <div className='relative w-full'>
             <div className='w-full mb-2'>
-              <img src={`${auctionDetails.imageUrls[0]}`} alt={auctionDetails.productName} className='object-cover w-full h-auto' />
+              <img
+                src={`${auctionDetails.imageUrls[0]}`}
+                alt={auctionDetails.productName}
+                className='object-cover w-full h-auto'
+              />
             </div>
             {/* 타이머 및 프로그레스 바 */}
             {auctionDetails && (
-              <div id='timer-section' className={`bg-white z-10 py-1 ${isTimerFixed ? 'fixed top-0 left-0 right-0' : ''}`}>
+              <div
+                id='timer-section'
+                className={`bg-white z-10 py-1 ${isTimerFixed ? 'fixed top-0 left-0 right-0' : ''}`}
+              >
                 <ProgressBar
                   initialTimeRemaining={auctionDetails.timeRemaining}
                   totalTime={totalTime} // Should be 86400
@@ -71,14 +78,25 @@ const AuctionDetails = () => {
             {/* 경매 아이템 제목 & 시작가 */}
             {auctionDetails && (
               <div className='mb-4'>
-                <p className='mb-1 text-lg font-bold'>{auctionDetails.productName || '[ERROR] 이름이 등록되지 않았어요!'}</p>
-                <p className='text-sm text-gray-500'>
+                <div className='mt-2 mb-2 flex flex-row items-center'>
+                  <div className='rounded-[50%] w-8 h-8 bg-slate-500' />
+                  <p className='ml-3 text-black'>
+                    {auctionDetails.sellerNickname}
+                  </p>
+                </div>
+                <p className='mt-2 mb-2 text-2xl font-bold'>
+                  {auctionDetails.productName ||
+                    '[ERROR] 이름이 등록되지 않았어요!'}
+                </p>
+                <p className='mt-2 mb-2 text-sm text-gray-500'>
                   <span className='inline-flex items-center'>
                     <span className='mr-1'>
                       <img src={Price} alt='Price' />
                     </span>
                     시작가
-                    <span className='font-bold p'>{numberWithCommas(Number(auctionDetails.minPrice))}원</span>
+                    <span className='font-bold p'>
+                      {numberWithCommas(Number(auctionDetails.minPrice))}원
+                    </span>
                   </span>
                 </p>
               </div>
@@ -92,16 +110,26 @@ const AuctionDetails = () => {
                     <span className='ml-1'>나의 참여 금액</span>
                   </div>
                   <p className='text-xl font-bold text-gray-800'>
-                    {auctionDetails.isParticipated ? `${numberWithCommas(Number(auctionDetails.bidAmount))}원` : '참여 전'}
+                    {auctionDetails.isParticipated
+                      ? `${numberWithCommas(Number(auctionDetails.bidAmount))}원`
+                      : '참여 전'}
                   </p>
                 </div>
                 <div className='h-full border-l border-gray-300' />
                 <div className='flex flex-col items-center flex-1 py-4 text-center'>
                   <div className='flex items-center mb-1 text-sm text-gray-400'>
-                    <img src={Participants} alt='Participants' className='w-4 h-4 mx-2 mb-1' />
+                    <img
+                      src={Participants}
+                      alt='Participants'
+                      className='w-4 h-4 mx-2 mb-1'
+                    />
                     <p className='mb-1 text-sm text-gray-500'>참여 인원</p>
                   </div>
-                  <p className='text-lg font-bold'>{auctionDetails.participantCount ? `${auctionDetails.participantCount}명` : '0명'}</p>
+                  <p className='text-lg font-bold'>
+                    {auctionDetails.participantCount
+                      ? `${auctionDetails.participantCount}명`
+                      : '0명'}
+                  </p>
                 </div>
               </div>
             </div>
@@ -115,7 +143,10 @@ const AuctionDetails = () => {
         {/* 화면 하단에 고정된 Footer */}
         <Layout.Footer type={isPreAuction ? 'double' : 'single'}>
           {auctionDetails && auctionDetails.isSeller ? (
-            <SellersFooter isSeller={auctionDetails.isSeller} status={auctionDetails.status} />
+            <SellersFooter
+              isSeller={auctionDetails.isSeller}
+              status={auctionDetails.status}
+            />
           ) : (
             <BuyersFooter
               auctionId={auctionId}
@@ -129,11 +160,19 @@ const AuctionDetails = () => {
         {/* 백드롭 */}
         {isMenuOpen && (
           <>
-            <div className='absolute inset-0 z-40 bg-black bg-opacity-50' onClick={closeMenu} style={{ top: 0, bottom: 0 }} />
+            <div
+              className='absolute inset-0 z-40 bg-black bg-opacity-50'
+              onClick={closeMenu}
+              style={{ top: 0, bottom: 0 }}
+            />
             {/* 메뉴 (아코디언) */}
             <div className='absolute top-[10px] right-2 bg-white shadow-lg rounded-md z-50'>
-              <button className='flex items-center w-full px-4 py-2 text-left text-gray-700 hover:bg-gray-200'>수정하기</button>
-              <button className='flex items-center w-full px-4 py-2 text-left text-red-600 hover:bg-red-100'>삭제하기</button>
+              <button className='flex items-center w-full px-4 py-2 text-left text-gray-700 hover:bg-gray-200'>
+                수정하기
+              </button>
+              <button className='flex items-center w-full px-4 py-2 text-left text-red-600 hover:bg-red-100'>
+                삭제하기
+              </button>
             </div>
           </>
         )}

--- a/src/pages/AuctionDetails.tsx
+++ b/src/pages/AuctionDetails.tsx
@@ -144,6 +144,7 @@ const AuctionDetails = () => {
         <Layout.Footer type={isPreAuction ? 'double' : 'single'}>
           {auctionDetails && auctionDetails.isSeller ? (
             <SellersFooter
+              auctionId={auctionId}
               isSeller={auctionDetails.isSeller}
               status={auctionDetails.status}
             />

--- a/src/pages/Payment.tsx
+++ b/src/pages/Payment.tsx
@@ -1,0 +1,11 @@
+import PaymentForm from '@/components/payment/PaymentForm';
+
+const Payment = () => {
+  return (
+    <div>
+      <PaymentForm />
+    </div>
+  );
+};
+
+export default Payment;

--- a/src/pages/PreAuctionDetails.tsx
+++ b/src/pages/PreAuctionDetails.tsx
@@ -86,7 +86,7 @@ const PreAuction = () => {
                       <img src={Price} alt='Price' />
                     </span>
                     시작가
-                    <span className='font-bold p'>
+                    <span className='font-bold'>
                       {formatCurrencyWithWon(preAuctionDetails.minPrice)}원
                     </span>
                   </span>

--- a/src/pages/PreAuctionDetails.tsx
+++ b/src/pages/PreAuctionDetails.tsx
@@ -50,11 +50,14 @@ const PreAuction = () => {
   // 삭제 확인 다이얼로그에서 '삭제' 버튼 클릭 핸들러
   const handleConfirmDelete = async () => {
     try {
-      await axios.delete(`${import.meta.env.VITE_API_URL}/api/v1/products/${preAuctionId}`, {
-        headers: {
-          Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
-        },
-      });
+      await axios.delete(
+        `${import.meta.env.VITE_API_URL}/api/v1/products/${preAuctionId}`,
+        {
+          headers: {
+            Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
+          },
+        }
+      );
       setIsDeleteConfirmOpen(false);
       setIsDeleteSuccessOpen(true);
     } catch (error) {
@@ -77,7 +80,11 @@ const PreAuction = () => {
           {/* 상품 이미지 영역 */}
           <div className='relative w-full bg-yellow-300'>
             <div className='w-full mb-2'>
-              <img src={preAuctionDetails?.imageUrls[0]} alt={preAuctionDetails?.productName} className='object-cover w-full h-auto' />
+              <img
+                src={preAuctionDetails?.imageUrls[0]}
+                alt={preAuctionDetails?.productName}
+                className='object-cover w-full h-auto'
+              />
             </div>
           </div>
 
@@ -86,14 +93,19 @@ const PreAuction = () => {
             {/* 경매 아이템 제목 & 시작가 */}
             {preAuctionDetails && (
               <div className='mb-4'>
-                <p className='mb-1 text-lg font-bold'>{preAuctionDetails.productName || '[ERROR] 이름이 등록되지 않았어요!'}</p>
+                <p className='mb-1 text-lg font-bold'>
+                  {preAuctionDetails.productName ||
+                    '[ERROR] 이름이 등록되지 않았어요!'}
+                </p>
                 <p className='text-sm text-gray-500'>
                   <span className='inline-flex items-center'>
                     <span className='mr-1'>
                       <img src={Price} alt='Price' />
                     </span>
                     시작가
-                    <span className='font-bold p'>{numberWithCommas(preAuctionDetails.minPrice)}원</span>
+                    <span className='font-bold p'>
+                      {numberWithCommas(preAuctionDetails.minPrice)}원
+                    </span>
                   </span>
                 </p>
               </div>
@@ -111,6 +123,7 @@ const PreAuction = () => {
             <SellersFooter
               likeCount={preAuctionDetails.likeCount}
               isSeller={preAuctionDetails.isSeller}
+              auctionId={preAuctionDetails.productId}
               status='PENDING'
             />
           ) : (
@@ -126,13 +139,22 @@ const PreAuction = () => {
         {/* 백드롭 */}
         {isMenuOpen && (
           <>
-            <div className='absolute inset-0 z-40 bg-black bg-opacity-50' onClick={closeMenu} />
+            <div
+              className='absolute inset-0 z-40 bg-black bg-opacity-50'
+              onClick={closeMenu}
+            />
             {/* 메뉴 (아코디언) */}
             <div className='absolute top-[10px] right-2 bg-white shadow-lg rounded-md z-50'>
-              <button className='flex items-center w-full px-4 py-2 text-left text-gray-700 hover:bg-gray-200' onClick={onEditButtonClickHandler}>
+              <button
+                className='flex items-center w-full px-4 py-2 text-left text-gray-700 hover:bg-gray-200'
+                onClick={onEditButtonClickHandler}
+              >
                 수정하기
               </button>
-              <button className='flex items-center w-full px-4 py-2 text-left text-red-600 hover:bg-red-100' onClick={onDeleteButtonClickHandler}>
+              <button
+                className='flex items-center w-full px-4 py-2 text-left text-red-600 hover:bg-red-100'
+                onClick={onDeleteButtonClickHandler}
+              >
                 삭제하기
               </button>
             </div>
@@ -141,10 +163,19 @@ const PreAuction = () => {
       </div>
       {/* 삭제 확인 다이얼로그 */}
       {isDeleteConfirmOpen && (
-        <ConfirmationModal message='정말 삭제하시겠습니까?' onConfirm={handleConfirmDelete} onCancel={() => setIsDeleteConfirmOpen(false)} />
+        <ConfirmationModal
+          message='정말 삭제하시겠습니까?'
+          onConfirm={handleConfirmDelete}
+          onCancel={() => setIsDeleteConfirmOpen(false)}
+        />
       )}
       {/* 삭제 성공 메시지 */}
-      {isDeleteSuccessOpen && <SuccessModal message='아이템이 삭제되었습니다.' onClose={handleCloseSuccessModal} />}
+      {isDeleteSuccessOpen && (
+        <SuccessModal
+          message='아이템이 삭제되었습니다.'
+          onClose={handleCloseSuccessModal}
+        />
+      )}
     </Layout>
   );
 };

--- a/src/pages/PreAuctionDetails.tsx
+++ b/src/pages/PreAuctionDetails.tsx
@@ -73,7 +73,11 @@ const PreAuction = () => {
 
   return (
     <Layout>
-      <Layout.Header title='제품 상세' handleModal={toggleMenu} />
+      <Layout.Header
+        title='제품 상세'
+        handleModal={toggleMenu}
+        isDisableMenuButton={!preAuctionDetails.isSeller}
+      />
       {/* 메인 컨텐츠가 스크롤 가능하도록 수정 */}
       <div className='relative flex flex-col h-screen overflow-hidden'>
         <Layout.Main>

--- a/src/pages/PreAuctionDetails.tsx
+++ b/src/pages/PreAuctionDetails.tsx
@@ -77,8 +77,7 @@ const PreAuction = () => {
             {preAuctionDetails && (
               <div className='mb-4'>
                 <p className='mb-1 text-lg font-bold'>
-                  {preAuctionDetails.productName ||
-                    '[ERROR] 이름이 등록되지 않았어요!'}
+                  {preAuctionDetails.productName}
                 </p>
                 <p className='text-sm text-gray-500'>
                   <span className='inline-flex items-center'>

--- a/src/pages/PreAuctionDetails.tsx
+++ b/src/pages/PreAuctionDetails.tsx
@@ -16,14 +16,16 @@ import { formatCurrencyWithWon } from '@/utils/formatCurrencyWithWon';
 const PreAuction = () => {
   const preAuctionId = useLoaderData() as number;
   const { preAuctionDetails } = useGetPreAuctionDetails(preAuctionId);
-  if (!preAuctionDetails) return null;
+  if (!preAuctionDetails) {
+    throw new Error('해당 사전 경매 정보를 찾을 수 없습니다.');
+  }
 
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
   const [isDeleteSuccessOpen, setIsDeleteSuccessOpen] = useState(false);
 
   const navigate = useNavigate();
-  const { mutate: deletePreAuction } = useDeletePreAuction(); // Use the custom hook
+  const { mutate: deletePreAuction } = useDeletePreAuction();
 
   const toggleMenu = () => setIsMenuOpen(!isMenuOpen);
   const closeMenu = () => setIsMenuOpen(false);
@@ -38,15 +40,11 @@ const PreAuction = () => {
     navigate(`/auctions/pre-auction/edit/${preAuctionDetails.productId}`);
   };
 
-  // Confirm delete handler
   const handleConfirmDelete = () => {
     deletePreAuction(preAuctionId, {
       onSuccess: () => {
         setIsDeleteConfirmOpen(false);
         setIsDeleteSuccessOpen(true);
-      },
-      onError: (error) => {
-        console.error('Failed to delete pre-auction:', error);
       },
     });
   };

--- a/src/pages/PreAuctionDetails.tsx
+++ b/src/pages/PreAuctionDetails.tsx
@@ -1,17 +1,16 @@
 /* eslint-disable prettier/prettier */
 import { useState } from 'react';
-
 import Layout from '@/components/layout/Layout';
-import { useNavigate, LoaderFunction, useLoaderData } from 'react-router-dom';
+import { useNavigate, useLoaderData, LoaderFunction } from 'react-router-dom';
 import Price from '@/assets/icons/price.svg';
-import axios from 'axios';
-
-// 필요한 컴포넌트 임포트
+import {
+  useDeletePreAuction,
+  useGetPreAuctionDetails,
+} from '@/components/details/queries';
 import SellersFooter from '@/components/details/SellersFooter';
 import BuyersFooter from '@/components/details/BuyersFooter';
 import ConfirmationModal from '@/components/details/ConfirmationModal';
 import SuccessModal from '@/components/details/SuccessModal';
-import { useGetPreAuctionDetails } from '@/components/details/queries';
 import { formatCurrencyWithWon } from '@/utils/formatCurrencyWithWon';
 
 const PreAuction = () => {
@@ -24,16 +23,12 @@ const PreAuction = () => {
   const [isDeleteSuccessOpen, setIsDeleteSuccessOpen] = useState(false);
 
   const navigate = useNavigate();
+  const { mutate: deletePreAuction } = useDeletePreAuction(); // Use the custom hook
 
-  const toggleMenu = () => {
-    setIsMenuOpen(!isMenuOpen);
-  };
+  const toggleMenu = () => setIsMenuOpen(!isMenuOpen);
+  const closeMenu = () => setIsMenuOpen(false);
 
-  const closeMenu = () => {
-    setIsMenuOpen(false);
-  };
-
-  // 삭제 버튼 클릭 핸들러
+  // Delete button click handler
   const onDeleteButtonClickHandler = () => {
     setIsDeleteConfirmOpen(true);
     closeMenu();
@@ -43,25 +38,20 @@ const PreAuction = () => {
     navigate(`/auctions/pre-auction/edit/${preAuctionDetails.productId}`);
   };
 
-  // 삭제 확인 다이얼로그에서 '삭제' 버튼 클릭 핸들러
-  const handleConfirmDelete = async () => {
-    try {
-      await axios.delete(
-        `${import.meta.env.VITE_API_URL}/api/v1/products/${preAuctionId}`,
-        {
-          headers: {
-            Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
-          },
-        }
-      );
-      setIsDeleteConfirmOpen(false);
-      setIsDeleteSuccessOpen(true);
-    } catch (error) {
-      console.error('삭제하는 중 오류가 발생했습니다.');
-    }
+  // Confirm delete handler
+  const handleConfirmDelete = () => {
+    deletePreAuction(preAuctionId, {
+      onSuccess: () => {
+        setIsDeleteConfirmOpen(false);
+        setIsDeleteSuccessOpen(true);
+      },
+      onError: (error) => {
+        console.error('Failed to delete pre-auction:', error);
+      },
+    });
   };
 
-  // 삭제 성공 메시지에서 '닫기' 버튼 클릭 핸들러
+  // Success modal close handler
   const handleCloseSuccessModal = () => {
     setIsDeleteSuccessOpen(false);
     navigate('/');
@@ -74,10 +64,8 @@ const PreAuction = () => {
         handleModal={toggleMenu}
         isDisableMenuButton={!preAuctionDetails.isSeller}
       />
-      {/* 메인 컨텐츠가 스크롤 가능하도록 수정 */}
       <div className='relative flex flex-col h-screen overflow-hidden'>
         <Layout.Main>
-          {/* 상품 이미지 영역 */}
           <div className='relative w-full bg-yellow-300'>
             <div className='w-full mb-2'>
               <img
@@ -87,10 +75,7 @@ const PreAuction = () => {
               />
             </div>
           </div>
-
-          {/* 경매 정보 영역 */}
           <div className='px-4 my-4'>
-            {/* 경매 아이템 제목 & 시작가 */}
             {preAuctionDetails && (
               <div className='mb-4'>
                 <p className='mb-1 text-lg font-bold'>
@@ -111,15 +96,12 @@ const PreAuction = () => {
               </div>
             )}
           </div>
-
-          {/* 상품 설명 */}
           <div className='px-4 mb-4 overflow-y-auto text-sm text-gray-700'>
             <p>{preAuctionDetails?.description}</p>
           </div>
         </Layout.Main>
-        {/* 화면 하단에 고정된 Footer */}
         <Layout.Footer type='double'>
-          {preAuctionDetails && preAuctionDetails.isSeller ? (
+          {preAuctionDetails.isSeller ? (
             <SellersFooter
               likeCount={preAuctionDetails.likeCount}
               isSeller={preAuctionDetails.isSeller}
@@ -136,14 +118,12 @@ const PreAuction = () => {
             />
           )}
         </Layout.Footer>
-        {/* 백드롭 */}
         {isMenuOpen && (
           <>
             <div
               className='absolute inset-0 z-40 bg-black bg-opacity-50'
               onClick={closeMenu}
             />
-            {/* 메뉴 (아코디언) */}
             <div className='absolute top-[10px] right-2 bg-white shadow-lg rounded-md z-50'>
               <button
                 className='flex items-center w-full px-4 py-2 text-left text-gray-700 hover:bg-gray-200'
@@ -161,7 +141,6 @@ const PreAuction = () => {
           </>
         )}
       </div>
-      {/* 삭제 확인 다이얼로그 */}
       {isDeleteConfirmOpen && (
         <ConfirmationModal
           message='정말 삭제하시겠습니까?'
@@ -169,7 +148,6 @@ const PreAuction = () => {
           onCancel={() => setIsDeleteConfirmOpen(false)}
         />
       )}
-      {/* 삭제 성공 메시지 */}
       {isDeleteSuccessOpen && (
         <SuccessModal
           message='아이템이 삭제되었습니다.'

--- a/src/pages/PreAuctionDetails.tsx
+++ b/src/pages/PreAuctionDetails.tsx
@@ -12,11 +12,12 @@ import BuyersFooter from '@/components/details/BuyersFooter';
 import ConfirmationModal from '@/components/details/ConfirmationModal';
 import SuccessModal from '@/components/details/SuccessModal';
 import { useGetPreAuctionDetails } from '@/components/details/queries';
+import { formatCurrencyWithWon } from '@/utils/formatCurrencyWithWon';
 
 const PreAuction = () => {
   const preAuctionId = useLoaderData() as number;
   const { preAuctionDetails } = useGetPreAuctionDetails(preAuctionId);
-  if (!preAuctionDetails) return;
+  if (!preAuctionDetails) return null;
 
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
@@ -30,11 +31,6 @@ const PreAuction = () => {
 
   const closeMenu = () => {
     setIsMenuOpen(false);
-  };
-
-  // 세자리 단위로 콤마를 찍어주는 함수
-  const numberWithCommas = (x: number) => {
-    return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
   };
 
   // 삭제 버튼 클릭 핸들러
@@ -61,7 +57,7 @@ const PreAuction = () => {
       setIsDeleteConfirmOpen(false);
       setIsDeleteSuccessOpen(true);
     } catch (error) {
-      alert('삭제하는 중 오류가 발생했습니다.');
+      console.error('삭제하는 중 오류가 발생했습니다.');
     }
   };
 
@@ -108,7 +104,7 @@ const PreAuction = () => {
                     </span>
                     시작가
                     <span className='font-bold p'>
-                      {numberWithCommas(preAuctionDetails.minPrice)}원
+                      {formatCurrencyWithWon(preAuctionDetails.minPrice)}원
                     </span>
                   </span>
                 </p>

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -84,6 +84,10 @@ const privateRouteList = [
     path: ROUTERS.ADDRESSBOOK,
     element: <AddressBook />,
   },
+  {
+    path: ROUTERS.PAYMENT,
+    element: <Payment />,
+  },
 ];
 
 const publicRouteList = [

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -4,7 +4,9 @@ import Register, { loader as registerLoader } from './pages/Register';
 
 import AddressBook from './pages/AddressBook';
 import AsyncBoundary from './components/common/loadingAndError/AsyncBoundary';
-import AuctionDetails, { loader as auctionDetailsLoader } from './pages/AuctionDetails';
+import AuctionDetails, {
+  loader as auctionDetailsLoader,
+} from './pages/AuctionDetails';
 import GlobalLayout from './components/layout/GlobalLayout';
 import Heart from './pages/Heart';
 import Home from './pages/Home';
@@ -13,7 +15,10 @@ import Login from './pages/Login';
 import NotFound from './components/common/loadingAndError/NotFound';
 import Notification from './pages/Notification';
 import OrderHistory from './pages/UserParticipatedList';
-import PreAuctionDetails, { loader as preAuctionDetailsLoader } from './pages/PreAuctionDetails';
+import Payment from './pages/Payment';
+import PreAuctionDetails, {
+  loader as preAuctionDetailsLoader,
+} from './pages/PreAuctionDetails';
 import PrivateRoute from './components/common/route/PrivateRoute';
 import ProductList from '@/pages/ProductList';
 import ProfileEdit from './pages/ProfileEdit';
@@ -105,7 +110,11 @@ export const router = createBrowserRouter([
         ),
         children: layoutWithNavRouteList.map(({ path, element }) => ({
           path,
-          element: <AsyncBoundary>{path === '/' ? element : <PrivateRoute>{element}</PrivateRoute>}</AsyncBoundary>,
+          element: (
+            <AsyncBoundary>
+              {path === '/' ? element : <PrivateRoute>{element}</PrivateRoute>}
+            </AsyncBoundary>
+          ),
         })),
       },
       ...privateRouteList.map(({ path, element, loader }) => ({
@@ -146,6 +155,9 @@ export const router = createBrowserRouter([
           </AsyncBoundary>
         ),
         loader: preAuctionDetailsLoader,
+      },
+      {
+        path: `${ROUTERS.PAYMENT}/:auctionId`,
       },
     ],
   },


### PR DESCRIPTION
## 💡 작업 내용

 **공통부분**
-[x]좌측에 하트, 좋아요를 누른 사람의 수, 우측에 primary 컬러의 버튼이 위치해야함

 **판매자**
 -[x]좌측의 하트 버튼은 클릭할 수 없음
 -[x] 좌측의 하트 버튼 옆에 좋아요를 누른 사람의 수가 보여져야함
 -[x]우측의 primary 컬러의 버튼은 '경매로 전환하기' 버튼이어야함
 -[x]우측의 primary 컬러의 버튼을 누르면 '경매로 전환하시겠습니까?' 라는 dialog가 실행되어야함
 -[x]경매로 전환을 확정하면 경매 등록 페이지로 넘어가야함

 **구매자**
 -[x]좌측의 하트 버튼은 클릭할 수 있고 클릭 시 하트의 색이 칠해져야함
 -[x]좌측의 하트 버튼 옆에 좋아요를 누른 사람의 수가 보여져야함
 -[x]우측의 primary 컬러의 버튼은 '오픈 알림 받기' 버튼이어야함
 -[x]우측의 primary 컬러의 버튼을 누르면 '해당 아이템의 경매 등록 소식을 받으시겠습니까?' 라는 dialog가 실행되어야함
 -[x]등록 소식을 받겠다는 버튼을 누르면 알림에 등록되어야함

## 💡 자세한 설명

(가능한 한 자세히 작성해 주시면 도움이 됩니다.)

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [ ] PR 제목을 형식에 맞게 작성했나요?
- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [ ] 이슈는 close 했나요?
- [ ] Reviewers, Labels, Projects를 등록했나요?
- [ ] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 테스트는 잘 통과했나요?
- [ ] 불필요한 코드는 제거했나요?

closes #88 
