### PR TITLE
Fix: 사전등록 수정시 이미지 처리 버그

### DIFF
--- a/src/@types/AuctionDetails.d.ts
+++ b/src/@types/AuctionDetails.d.ts
@@ -5,7 +5,10 @@ declare module 'AuctionDetails' {
     productName: string;
     description: string;
     minPrice: number;
-    imageUrls: string[];
+    images: {
+      imageId: number;
+      imageUrl: string;
+    }[];
     isSeller: boolean;
     category: string;
   }

--- a/src/@types/AuctionDetails.d.ts
+++ b/src/@types/AuctionDetails.d.ts
@@ -5,10 +5,6 @@ declare module 'AuctionDetails' {
     productName: string;
     description: string;
     minPrice: number;
-    images: {
-      imageId: number;
-      imageUrl: string;
-    }[];
     isSeller: boolean;
     category: string;
   }
@@ -21,11 +17,16 @@ declare module 'AuctionDetails' {
     bidId: number | null;
     bidAmount: number;
     remainingBidCount: number;
+    imageUrls: string[];
   }
 
   export interface IPreAuctionDetails extends IAuctionDetailsBase {
     createdAt: string;
     likeCount: number;
     isLiked: boolean;
+    images: {
+      imageId: number;
+      imageUrl: string;
+    }[];
   }
 }

--- a/src/@types/Register.d.ts
+++ b/src/@types/Register.d.ts
@@ -5,5 +5,6 @@ declare module 'Register' {
     minPrice: number;
     auctionRegisterType?: string;
     category: string;
+    imageSequence?: Map<number, number>;
   }
 }

--- a/src/components/register/ImageUploader.tsx
+++ b/src/components/register/ImageUploader.tsx
@@ -1,7 +1,6 @@
 import DeleteIcon from '@/assets/icons/delete.svg';
 import { useDragAndDrop } from '@/hooks/useDragAndDrop';
 import { useImageUploader } from '@/hooks/useImageUploader';
-import { Dispatch, SetStateAction } from 'react';
 import CustomCarousel from '../common/CustomCarousel';
 import { CarouselItem } from '../ui/carousel';
 import { Input } from '../ui/input';
@@ -10,16 +9,14 @@ import AddImageButton from './AddImageButton';
 interface ImageUploaderProps {
   images: string[];
   setImages: (value: string[]) => void;
-  files: File[];
-  setFiles: Dispatch<SetStateAction<File[]>>;
 }
 
-const ImageUploader = ({ files, setFiles, images, setImages }: ImageUploaderProps) => {
+const ImageUploader = ({ images, setImages }: ImageUploaderProps) => {
   const { handleDragStart, handleDragLeave, handleDragOver, handleDrop, hoveredIndex } = useDragAndDrop(images, setImages);
-  const { fileInputRef, deleteImage, handleImage, handleBoxClick } = useImageUploader(images, setImages, files, setFiles);
+  const { fileInputRef, deleteImage, handleImage, handleBoxClick } = useImageUploader(images, setImages);
 
   return (
-    <div className='flex flex-col items-center w-full h-32 gap-5 sm:flex-row'>
+    <div className='flex flex-col items-center w-full h-full gap-5 sm:h-32 sm:flex-row'>
       <AddImageButton handleBoxClick={handleBoxClick} length={images.length} />
       <CustomCarousel contentStyle='py-2' length={images.length}>
         {images.map((image: string, index: number) => (

--- a/src/hooks/useImageUploader.ts
+++ b/src/hooks/useImageUploader.ts
@@ -1,11 +1,6 @@
-import { ChangeEvent, Dispatch, SetStateAction, useRef } from 'react';
+import { ChangeEvent, useRef } from 'react';
 
-export const useImageUploader = (
-  state: string[],
-  setState: (images: string[]) => void,
-  files: File[],
-  setFiles: Dispatch<SetStateAction<File[]>>,
-) => {
+export const useImageUploader = (state: string[], setState: (images: string[]) => void) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const convertFileToDataURL = (file: File): Promise<string> => {
@@ -13,8 +8,7 @@ export const useImageUploader = (
       const reader = new FileReader();
       reader.readAsDataURL(file);
       reader.onload = () => {
-        if (reader.result && typeof reader.result === 'string')
-          resolve(reader.result);
+        if (reader.result && typeof reader.result === 'string') resolve(reader.result);
         else reject(new Error('File reading failed!'));
       };
       reader.onerror = () => reject(new Error('File reading failed!'));
@@ -23,12 +17,8 @@ export const useImageUploader = (
 
   const addImages = async (newFiles: File[]) => {
     try {
-      const newImages = await Promise.all(
-        newFiles.map(async (newFile) => convertFileToDataURL(newFile)),
-      );
+      const newImages = await Promise.all(newFiles.map(async (newFile) => convertFileToDataURL(newFile)));
       const imgArr = Array.from(new Set([...state, ...newImages]));
-      const fileArr = Array.from(new Set([...files, ...newFiles]));
-      setFiles(fileArr);
       setState(imgArr);
     } catch (error) {
       throw new Error('Error reading file!');
@@ -44,7 +34,6 @@ export const useImageUploader = (
   };
 
   const deleteImage = (targetIdx: number) => {
-    setFiles(files.filter((_, idx) => idx !== targetIdx));
     setState(state.filter((_, idx) => idx !== targetIdx));
   };
 
@@ -53,7 +42,6 @@ export const useImageUploader = (
   };
 
   return {
-    files,
     fileInputRef,
     deleteImage,
     handleImage,

--- a/src/pages/PreAuctionDetails.tsx
+++ b/src/pages/PreAuctionDetails.tsx
@@ -1,15 +1,15 @@
 /* eslint-disable prettier/prettier */
 import { useState } from 'react';
 
-import Layout from '@/components/layout/Layout';
-import { useNavigate, LoaderFunction, useLoaderData } from 'react-router-dom';
 import Price from '@/assets/icons/price.svg';
+import Layout from '@/components/layout/Layout';
 import axios from 'axios';
+import { LoaderFunction, useLoaderData, useNavigate } from 'react-router-dom';
 
 // 필요한 컴포넌트 임포트
-import SellersFooter from '@/components/details/SellersFooter';
 import BuyersFooter from '@/components/details/BuyersFooter';
 import ConfirmationModal from '@/components/details/ConfirmationModal';
+import SellersFooter from '@/components/details/SellersFooter';
 import SuccessModal from '@/components/details/SuccessModal';
 import { useGetPreAuctionDetails } from '@/components/details/queries';
 
@@ -77,7 +77,7 @@ const PreAuction = () => {
           {/* 상품 이미지 영역 */}
           <div className='relative w-full bg-yellow-300'>
             <div className='w-full mb-2'>
-              <img src={preAuctionDetails?.imageUrls[0]} alt={preAuctionDetails?.productName} className='object-cover w-full h-auto' />
+              <img src={preAuctionDetails?.images.map(el => el.imageUrl)[0]} alt={preAuctionDetails?.productName} className='object-cover w-full h-auto' />
             </div>
           </div>
 

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -42,7 +42,7 @@ const Register = () => {
   const navigate = useNavigate();
   const [caution, setCaution] = useState<string>('');
   const [check, setCheck] = useState<boolean>(false);
-  const [existingImage, setExistingImage] = useState<{ imageId: number; imageUrl: string; firstIdx: number }[]>([])
+  const [existingImages, setExistingImages] = useState<{ imageId: number; imageUrl: string; firstIdx: number }[]>([])
   const {
     control,
     handleSubmit,
@@ -79,7 +79,7 @@ const Register = () => {
 
     // 기존의 이미지가 현재 어느 위치에 있는지 계산
     let imageSequence = new Map<number, number>()
-    if (preAuctionId) existingImage.map((el) => {
+    if (preAuctionId) existingImages.map((el) => {
       for (const sequence of previewImageSequence) {
         if (el.imageUrl === sequence.image) {
           imageSequence.set(el.imageId, sequence.id)
@@ -113,7 +113,7 @@ const Register = () => {
       const { productName, images, category, description, minPrice } = preAuctionDetails;
       setValue('productName', productName);
       setValue('images', images.map(el => el.imageUrl));
-      setExistingImage(images.map((image, idx) => ({ ...image, firstIdx: idx + 1 })))
+      setExistingImages(images.map((image, idx) => ({ ...image, firstIdx: idx + 1 })))
       setValue('description', description);
       setValue('minPrice', formatCurrencyWithWon(minPrice));
       setValue('category', CATEGORIES[category].code); // 카테고리 기본 값 설정

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -95,9 +95,6 @@ const Register = () => {
       ...(preAuctionId ? { imageSequence } : { auctionRegisterType: caution }),
     };
 
-    console.log(submitData)
-    console.log(newFiles)
-
     formData.append(
       'request',
       new Blob([JSON.stringify(submitData)], {

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -92,9 +92,9 @@ const Register = () => {
 
   useEffect(() => {
     if (preAuctionDetails) {
-      const { productName, imageUrls, category, description, minPrice } = preAuctionDetails;
+      const { productName, images, category, description, minPrice } = preAuctionDetails;
       setValue('productName', productName);
-      setValue('images', imageUrls);
+      setValue('images', images.map(el => el.imageUrl));
       setValue('description', description);
       setValue('minPrice', formatCurrencyWithWon(minPrice));
       setValue('category', CATEGORIES[category].code); // 카테고리 기본 값 설정

--- a/src/utils/dataURLToFile.ts
+++ b/src/utils/dataURLToFile.ts
@@ -1,0 +1,31 @@
+export const dataURLtoFile = (dataURL: string): File => {
+  // DataURL에서 Base64와 MIME 타입 추출
+  const arr = dataURL.split(',');
+  const mimeMatch = arr[0].match(/data:(.*?);base64/);
+  if (!mimeMatch) throw new Error('잘못된 DataURL형식입니다.');
+
+  const mime = mimeMatch[1];
+  const bstr = atob(arr[1]);
+  let n = bstr.length;
+  const u8arr = new Uint8Array(n);
+
+  // Base64를 바이트 배열로 변환
+  while (n--) {
+    u8arr[n] = bstr.charCodeAt(n);
+  }
+
+  // MIME 타입으로부터 확장자 추출
+  const mimeToExtensionMap: { [key: string]: string } = {
+    'image/jpeg': 'jpg',
+    'image/png': 'png',
+  };
+
+  // MIME 타입이 지도된 확장자가 있는 경우에만 파일 생성
+  const extension = mimeToExtensionMap[mime];
+  if (!extension) throw new Error(`${mime}은 지원되지 않는 MIME 타입입니다.`);
+
+  const fileName = `image.${extension}`; // idx를 사용한 파일 이름
+
+  // 새로운 File 객체 생성
+  return new File([u8arr], fileName, { type: mime });
+};


### PR DESCRIPTION
## 💡 작업 내용

- [x] 사전등록 상세조회 이미지 타입 변경
- [x] 기존 이미지(existingImages) 변수 선언
- [x] File 타입 이미지 변수 삭제
- [x] 기존 이미지가 사용자가 수정할 이미지의 몇 번째 순서에 있는지 계산.
- [x] 새로운 이미지를 보낼 때 수정할 이미지의 순서를 key 값으로 전송 
- [x] dataURL 이미지를 File 타입 변경 함수 선언
- [x] 이미지 등록 시 크기 변하는 버그 수정

## 💡 자세한 설명

기존 이미지(DB에 저장된 이미지의 id와 URL)를 existingImages에 따로 저장해두고,
사용자의 preview로 사용할 이미지의 초기값으로 저장한다.
사용자는 preview에 저장된 이미지의 순서를 변경하고 삭제하고 새로운 이미지를 저장하여 변하는 값이지만,  existingImages는 변하지 않는다.

최종 수정할 때 preview에는 두 가지 타입의 이미지가 있다.
하나는 data:로 시작하는 이미지로, 사용자가 file input으로 새로 삽입한 이미지이며 미리보기를 위해 dataURL로 변환한 값이다.
나머지는 DB에서 받아온 기존이미지의 URL이다.

data:로 시작하는 새로 받은 이미지만 따로 뽑아서 dataURLtoFile 함수를 통해 다시 File 타입으로 변환하고, 이 새로 삽입한 이미지가 preview에서 몇 번째에 위치하는지 기록한다. 전송할 때, formData의 key 값에는 preview의 index를 넣고 value에 file 타입 데이터를 전송한다.

기존 이미지가 현재 어느 위치에 있는지 계산하여 imageSequence 변수에 저장한다.
existingImages를 조회해서 기존 이미지가 preview에서 어느 위치에 있는지 확인하고, Map 자료구조의 key값으로는 이미지의 id값, value값으로는 이 이미지의 preview index값을 기록한다.
삭제된 이미지는 기록하지 않고 현재 존재하는 이미지가 어느 index에 있는지만 기록한다.

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #119 
